### PR TITLE
prometheus_external_labels variable assignment dynamically

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,12 +22,12 @@ prometheus_alertmanager_config: []
 #    proxy_url: "127.0.0.2"
 
 prometheus_global:
-  scrape_interval: 15s
-  scrape_timeout: 10s
+  scrape_interval: 60s
+  scrape_timeout: 15s
   evaluation_interval: 15s
 
 prometheus_external_labels:
-  environment: "{{ ansible_domain }}"
+  environment: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"
 
 prometheus_config_flags_extra: {}
 


### PR DESCRIPTION
- prometheus_external_labels variable assignment dynamically
- increase default prometheus global scrape interval to 60s