### PR TITLE
Add newline before [Unit] section in service file

### DIFF
--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -1,9 +1,9 @@
-# {{ ansible_managed }}
 {%- if prometheus_version | version_compare('2.0.0', '>=') %}
 {%- set pre = '-' %}
 {%- else %}
 {%- set pre = '' %}
 {%- endif %}
+# {{ ansible_managed }}
 [Unit]
 Description=Prometheus
 After=network.target


### PR DESCRIPTION
Without this fix my .service file ends up looking like this:

```
# Ansible managed[Unit]
Description=Prometheus
After=network.target
...
```