### PR TITLE
Wrong indent

### DIFF
--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -46,5 +46,5 @@ scrape_configs:
 
 # experimental support for all type of scrape jobs
 {% for scrape in prometheus_scrape_jobs %}
-  - {{ scrape | to_nice_yaml(indent=2) | indent(2, False) }}
+  - {{ scrape | to_nice_yaml(indent=4) | indent(4, False) }}
 {% endfor %}


### PR DESCRIPTION
This fixes build error in our [demo site](https://github.com/cloudalchemy/demo-site) which occured after adding blackbox-exporter configuration: https://github.com/cloudalchemy/demo-site/blob/master/group_vars/all/vars#L20

@rdemachkovych if everything is ok, please merge it.