### PR TITLE
armv7l ansible arch translates to armv7 go arch

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 go_arch_map:
   x86_64: amd64
   aarch64: arm64
-  armv7l: arm7
+  armv7l: armv7


### PR DESCRIPTION
The architecture name used in prometheus releases for armv7l is armv7