### PR TITLE
Update generatetag.sh

### DIFF
--- a/.travis/generatetag.sh
+++ b/.travis/generatetag.sh
@@ -6,7 +6,7 @@ git tag --points-at
 
 git config --global user.email "paulfantom@gmail.com"
 git config --global user.name "paulfantom"
-GIT_TAG=$([[ "$TRAVIS_COMMIT_MESSAGE" =~ ("Merge pull request".*/feature.*) ]] && git semver --next-minor || git semver --next-patch )
+GIT_TAG=$([[ "$TRAVIS_COMMIT_MESSAGE" =~ ("Merge pull request".*[feature].*) ]] && git semver --next-minor || git semver --next-patch )
 echo $GIT_TAG
 git tag $GIT_TAG -a -m "Generated tag from TravisCI for build $TRAVIS_BUILD_NUMBER"
 GIT_URL=$(git config --get remote.origin.url)


### PR DESCRIPTION
This should help in semantic versioning. It gives us an option to bump minor version just by adding `[feature]` in merge message instead of relying on branch naming.

This was tested in commit https://github.com/SoInteractive/ansible-tests/commit/6871d9906faa9d44fa87e1a70678a8de0df994b7