### PR TITLE
Simplify scrape configs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,14 +46,14 @@ prometheus_targets: []
 
 prometheus_scrape_configs:
 - job_name: "prometheus"
-  metrics_path: {{ prometheus_metrics_path }}
+  metrics_path: "{{ prometheus_metrics_path }}"
   static_configs:
   - targets:
     - "{{ ansible_fqdn | default(ansible_host) | default('localhost') }}:9090"
 - job_name: "node"
   file_sd_configs:
   - files:
-    - {{ prometheus_config_dir }}/file_sd/targets.yml
+    - "{{ prometheus_config_dir }}/file_sd/targets.yml"
 
 # Alternative config file name, searched in ansible templates path.
 prometheus_config_file: 'prometheus.yml.j2'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,13 +44,16 @@ prometheus_targets: []
 #    env: test
 #    job: node
 
-prometheus_scrape_jobs: []
-#prometheus_scrape_jobs:
-#- job_name: "node"
-#  metrics_path: /metrics
-#  static_configs:
-#  - targets:
-#    - "demo.cloudalchemy.org:9100"
+prometheus_scrape_configs:
+- job_name: "prometheus"
+  metrics_path: {{ prometheus_metrics_path }}
+  static_configs:
+  - targets:
+    - "{{ ansible_fqdn | default(ansible_host) | default('localhost') }}:9090"
+- job_name: "node"
+  file_sd_configs:
+  - files:
+    - {{ prometheus_config_dir }}/file_sd/targets.yml
 
 # Alternative config file name, searched in ansible templates path.
 prometheus_config_file: 'prometheus.yml.j2'

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -19,19 +19,4 @@ alerting:
 {% endif %}
 
 scrape_configs:
-  - job_name: "prometheus"
-    scheme: http
-    metrics_path: {{ prometheus_metrics_path }}
-    static_configs:
-    - targets:
-      - "{{ ansible_fqdn | default(ansible_host) | default('localhost') }}:9090"
-
-  - job_name: "node"
-    metrics_path: /metrics
-    file_sd_configs:
-    - files:
-      - {{ prometheus_config_dir }}/file_sd/*.yml
-      - {{ prometheus_config_dir }}/file_sd/*.yaml
-      - {{ prometheus_config_dir }}/file_sd/*.json
-
-  {{ prometheus_scrape_jobs | to_nice_yaml(indent=2) | indent(2,False) }}
+  {{ prometheus_scrape_configs | to_nice_yaml(indent=2) | indent(2,False) }}

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -7,7 +7,7 @@ prometheus_targets:
   labels:
     env: test
     job: node
-prometheus_scrape_jobs:
+prometheus_scrape_configs:
 - job_name: 'blackbox'
   metrics_path: /probe
   params:


### PR DESCRIPTION
Define all scrape configs as a single default variable.  This allows for
simpler templating of the `prometheus.yml`.

Closes: https://github.com/cloudalchemy/ansible-prometheus/issues/45