### PR TITLE
adapt prometheus binary placement to hier(7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `prometheus_version` | 2.0.0  | Prometheus package version |
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
 | `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
-| `prometheus_root_dir` | /opt/prometheus | Path to directory with prometheus and promtool binaries |
+| `prometheus_root_dir` | /usr/local/bin | Path to directory with prometheus and promtool binaries |
 | `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |
 | `prometheus_web_external_url` | "" | External address on which prometheus is available. Useful when behind reverse proxy. Ex. `example.org/prometheus` |
 | `prometheus_storage_retention` | "30d" | Data retention period |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ prometheus_version: 2.1.0
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus
-prometheus_root_dir: /opt/prometheus
+prometheus_root_dir: /usr/local/bin
 
 prometheus_web_listen_address: "0.0.0.0:9090"
 prometheus_web_external_url: ''

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,6 +39,16 @@
   delegate_to: localhost
   check_mode: no
 
+- name: remove prometheus binaries from old location
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /opt/prometheus/prometheus
+    - /opt/prometheus/promtool
+    - /opt/prometheus
+  when: prometheus_root_dir != /opt/prometheus
+
 - name: propagate prometheus and promtool binaries
   copy:
     src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/{{ item }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,7 +47,7 @@
     - /opt/prometheus/prometheus
     - /opt/prometheus/promtool
     - /opt/prometheus
-  when: prometheus_root_dir != /opt/prometheus
+  when: prometheus_root_dir != "/opt/prometheus"
 
 - name: propagate prometheus and promtool binaries
   copy:

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -5,7 +5,6 @@ testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
 
 def test_files(host):
     dirs = [
-        "/opt/prometheus",
         "/etc/prometheus",
         "/etc/prometheus/rules",
         "/etc/prometheus/file_sd",
@@ -16,8 +15,8 @@ def test_files(host):
         "/etc/prometheus/rules/ansible_managed.rules",
         "/etc/prometheus/file_sd/node.yml",
         "/etc/systemd/system/prometheus.service",
-        "/opt/prometheus/prometheus",
-        "/opt/prometheus/promtool"
+        "/usr/local/bin/prometheus",
+        "/usr/local/bin/promtool"
     ]
     for directory in dirs:
         d = host.file(directory)


### PR DESCRIPTION
We should use /usr/local/bin for storing binary packages instead of /opt