### PR TITLE
specify which tasks should use superuser permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 ```yaml
 ---
 - hosts: all
-  become: yes
   roles:
   - cloudalchemy.prometheus
   vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,13 @@
 - include: preflight.yml
 
 - include: install.yml
+  become: yes
 
 - include: configure.yml
+  become: yes
 
 - name: ensure prometheus service is started and enabled
+  become: yes
   systemd:
     name: prometheus
     state: started


### PR DESCRIPTION
This should allow using this role without specifying `become: yes` at a playbook level.