### PR TITLE
Make Prometheus daemon restart/reload with sudo privileges.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,13 @@
 ---
 - name: restart prometheus
+  become: true
   systemd:
     daemon_reload: yes
     name: prometheus
     state: restarted
 
 - name: reload prometheus
+  become: true
   systemd:
     name: prometheus
     state: reloaded


### PR DESCRIPTION
I'm trying to include the `cloudalchemy.prometheus` role from our own monitoring role like this:
```
- name: Install Prometheus Server
  become: yes
  when: act_as_prometheus_server == true

  include_role:
    name: cloudalchemy.prometheus
  vars:
  [...]
```

This results in a fatal error, at the point when running the handler that should restart prometheus:
```
RUNNING HANDLER [cloudalchemy.prometheus : restart prometheus] **********************************************************************************************************************
fatal: [monitor]: FAILED! => {"changed": false, "msg": "failure 1 during daemon-reload: Failed to execute operation: Interactive authentication required.\n"}
```
The service could only be restarted with sudo-privileges, which in the case of an `include_role` or `import_role` won't get picked up correctly by the handler responsible for the service-restart/-reload.
 This PR will make sure that the `prometheus.service` will be restarted with the correct privileges.