### PR TITLE
SELinux support

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -78,6 +78,26 @@
   notify:
     - restart prometheus
 
+- name: Install SELinux dependencies on RedHat OS family
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libselinux-python
+    - policycoreutils-python
+  when:
+    - ansible_os_family == "RedHat"
+
+- name: Allow prometheus to bind to port in SELinux on RedHat OS family
+  seport:
+    ports: "{{ prometheus_web_listen_address.split(':')[1] }}"
+    proto: tcp
+    setype: http_port_t
+    state: present
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_virtualization_type != "docker"
+
 #- name: change pam nofile limits for prometheus
 #  pam_limits:
 #    domain: "prometheus"


### PR DESCRIPTION
This cannot be properly tested with docker CI pipeline established here.

It should enable running prometheus on RedHat systems with SELinux in enforcing mode.