### PR TITLE
bump prometheus version to 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `prometheus_version` | 2.1.0  | Prometheus package version |
+| `prometheus_version` | 2.2.0  | Prometheus package version |
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
 | `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
 | `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-prometheus_version: 2.1.0
+prometheus_version: 2.2.0
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus


### PR DESCRIPTION
Prometheus 2.2 is already [here](https://github.com/prometheus/prometheus/releases/tag/v2.2.0) (but without release notes) so this PR just bumps default version used.