### PR TITLE
Modify when-statement to not include jinja2 templating delimiters

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -37,7 +37,8 @@
 - name: Fail when prometheus_config_flags_extra duplicates parameters set by other variables
   fail:
     msg: "Whooops. You are duplicating configuration. Please look at your prometheus_config_flags_extra and check against other variables in defaults/main.yml"
-  when: "{{ [ 'storage.tsdb.retention', 'storage.tsdb.path', 'storage.local.retention', 'storage.local.path', 'config.file', 'web.listen-address', 'web.external-url' ] | intersect(prometheus_config_flags_extra.keys()) }}"
+  with_items: [ 'storage.tsdb.retention', 'storage.tsdb.path', 'storage.local.retention', 'storage.local.path', 'config.file', 'web.listen-address', 'web.external-url' ]
+  when: item in prometheus_config_flags_extra.keys()
 
 - name: Get all file_sd files from scrape_configs
   set_fact:


### PR DESCRIPTION
As from Ansible 2.3 a warning will be raised when jinja2 templating delimiters are used in when-statements. This PR will refactor the when-statement in the task that tests for `prometheus_config_flags_extra` intersecting with parameters set by other variables.