### PR TITLE
ansible 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE='ansible>=2.2.0,<2.3.0' PROMETHEUS=1.8.2
-  - ANSIBLE='ansible>=2.2.0,<2.3.0' PROMETHEUS=2.2.1
   - ANSIBLE='ansible>=2.3.0,<2.4.0' PROMETHEUS=1.8.2
   - ANSIBLE='ansible>=2.3.0,<2.4.0' PROMETHEUS=2.2.1
   - ANSIBLE='ansible>=2.4.0,<2.5.0' PROMETHEUS=1.8.2
   - ANSIBLE='ansible>=2.4.0,<2.5.0' PROMETHEUS=2.2.1
+  - ANSIBLE='ansible>=2.5.0,<2.6.0' PROMETHEUS=1.8.2
+  - ANSIBLE='ansible>=2.5.0,<2.6.0' PROMETHEUS=2.2.1
 install:
   -  pip install ${ANSIBLE} 'ansible-lint>=3.4.15' 'molecule==1.25.0' docker git-semver 'testinfra>=1.7.0,<=1.10.1' jmespath
 before_script:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Deploy [Prometheus](https://github.com/prometheus/prometheus) monitoring system 
 
 ## Requirements
 
-- Ansible > 2.2
+- Ansible >= 2.3
 - go-lang installed on deployer machine (same one where ansible is installed)
 - jmespath on deployer machine. If you are using Ansble from a Python virtualenv, install *jmespath* to the same virtualenv via pip.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Roman Demachkovych, Pawel Krupa
   description: Deploy Prometheus monitoring system
   license: MIT
-  min_ansible_version: 2.2
+  min_ansible_version: 2.3
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
Ansible released new "2.5" version. This PR adds support for testing role against this version.
Also this drops support for version 2.2