### PR TITLE
Quick fix to allow multi-arch environments support

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,7 +45,7 @@
   until: _download_binary | success
   retries: 5
   delay: 2
-  run_once: true
+  # run_once: true
   delegate_to: localhost
   check_mode: no
 


### PR DESCRIPTION
`run_once` will cause problems with multi-arch environments since this role will download only one binary version.