### PR TITLE
use new filter schema

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,7 @@
     remote_src: yes
     creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/prometheus"
   register: _download_binary
-  until: _download_binary | success
+  until: _download_binary is success
   retries: 5
   delay: 2
   # run_once: true
@@ -90,7 +90,7 @@
     - libselinux-python
     - policycoreutils-python
   register: _download_packages
-  until: _download_packages | success
+  until: _download_packages is success
   retries: 5
   delay: 2
   when:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,7 @@
     remote_src: yes
     creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/prometheus"
   register: _download_binary
-  until: _download_binary is success
+  until: _download_binary is succeeded
   retries: 5
   delay: 2
   # run_once: true
@@ -90,7 +90,7 @@
     - libselinux-python
     - policycoreutils-python
   register: _download_packages
-  until: _download_packages is success
+  until: _download_packages is succeeded
   retries: 5
   delay: 2
   when:

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -2,13 +2,13 @@
   set_fact:
     prometheus_config_validator: "/usr/local/bin/promtool check config %s"
     prometheus_rules_validator: "/usr/local/bin/promtool check rules %s"
-  when: prometheus_version | version_compare('2.0.0', '>=')
+  when: prometheus_version is version_compare('2.0.0', '>=')
 
 - name: Set validator commands for prometheus 1.x
   set_fact:
     prometheus_config_validator: "/usr/local/bin/promtool check-config %s"
     prometheus_rules_validator: "/usr/local/bin/promtool check-rules %s"
-  when: prometheus_version | version_compare('2.0.0', '<')
+  when: prometheus_version is version_compare('2.0.0', '<')
 
 - name: Check if extra config flags are duplicating ansible variables
   fail:
@@ -32,7 +32,7 @@
 - name: Set storage retention setting
   set_fact:
     prometheus_storage_retention: "{{ (prometheus_storage_retention | regex_search('\\d+') | int ) * 24 }}h0m0s"
-  when: prometheus_version | version_compare('2.0.0', '<')
+  when: prometheus_version is version_compare('2.0.0', '<')
 
 - name: Fail when prometheus_config_flags_extra duplicates parameters set by other variables
   fail:


### PR DESCRIPTION
Use newer [test filter schema](https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#test-syntax

This will remove some deprecation warnings. It should leave only ones regarding `include` statement