### PR TITLE
add checksum verification

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -39,6 +39,7 @@
   get_url:
     url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
     dest: "/tmp"
+    checksum: "sha256:{{ prometheus_checksum }}"
   register: _download_archive
   until: _download_archive is succeeded
   retries: 5

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -68,3 +68,10 @@
     set_fact:
       prometheus_version: "{{ _latest_release.json.tag_name[1:] }}"
   when: prometheus_version == "latest"
+
+- name: "Get checksum for {{ go_arch_map[ansible_architecture] | default(ansible_architecture) }} architecture"
+  set_fact:
+    prometheus_checksum: "{{ item.split(' ')[0] }}"
+  with_items:
+    - "{{ lookup('url', 'https://github.com/prometheus/prometheus/releases/download/v' + prometheus_version + '/sha256sums.txt', wantlist=True) | list }}"
+  when: "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"


### PR DESCRIPTION
Resolves #104 

Checksum download is done in one task which does the following:
1) downloads `sha256sums.txt` from assets in chosen program version (download with `lookup` `url` plugin)
2) iterates over lines in file to grep one with proper CPU architecture
3) splits line to extract only checksum value

Basically it does the same as (for prometheus version 2.2.1):
```
curl -L https://github.com/prometheus/prometheus/releases/download/v2.2.1/sha256sums.txt 2>/dev/null | grep linux-amd64 | awk -F ' ' '{ print $1 }'
```