### PR TITLE
take care of SELinux only when it is enabled

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -93,14 +93,13 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items:
-    - libselinux-python
-    - policycoreutils-python
-  register: _download_packages
-  until: _download_packages is succeeded
+  with_items: "{{ prometheus_selinux_packages }}"
+  register: _install_packages
+  until: _install_packages is succeeded
   retries: 5
   delay: 2
   when:
+    - ansible_version.full is version_compare('2.4', '>=')
     - ansible_selinux.status == "enabled"
 
 - name: Allow prometheus to bind to port in SELinux
@@ -110,6 +109,7 @@
     setype: http_port_t
     state: present
   when:
+    - ansible_version.full is version_compare('2.4', '>=')
     - ansible_selinux.status == "enabled"
 
 # - name: change pam falsefile limits for prometheus

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -89,7 +89,7 @@
   notify:
     - restart prometheus
 
-- name: Install SELinux dependencies on RedHat OS family
+- name: Install SELinux dependencies
   package:
     name: "{{ item }}"
     state: present
@@ -101,17 +101,16 @@
   retries: 5
   delay: 2
   when:
-    - ansible_os_family == "RedHat"
+    - ansible_selinux.status == "enabled"
 
-- name: Allow prometheus to bind to port in SELinux on RedHat OS family
+- name: Allow prometheus to bind to port in SELinux
   seport:
     ports: "{{ prometheus_web_listen_address.split(':')[1] }}"
     proto: tcp
     setype: http_port_t
     state: present
   when:
-    - ansible_os_family == "RedHat"
-    - ansible_virtualization_type != "docker"
+    - ansible_selinux.status == "enabled"
 
 # - name: change pam falsefile limits for prometheus
 #   pam_limits:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Gather variables for each operating system
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution | lower }}.yml"
+    - "{{ ansible_os_family | lower }}.yml"
+  tags:
+    - always
+
 - include: preflight.yml
 
 - include: install.yml

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,4 @@
+---
+prometheus_selinux_packages:
+  - python-selinux
+  - policycoreutils

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,4 @@
+---
+prometheus_selinux_packages:
+  - libselinux-python
+  - policycoreutils-python


### PR DESCRIPTION
Manage SELinux not only on RedHat family systems, but when it is enabled.

Resolves #111 