### PR TITLE
Remove prometheus 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,8 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE='ansible>=2.3.0,<2.4.0' PROMETHEUS=1.8.2
-  - ANSIBLE='ansible>=2.3.0,<2.4.0' PROMETHEUS=2.2.1
-  - ANSIBLE='ansible>=2.4.0,<2.5.0' PROMETHEUS=1.8.2
-  - ANSIBLE='ansible>=2.4.0,<2.5.0' PROMETHEUS=2.2.1
-  - ANSIBLE='ansible>=2.5.0,<2.6.0' PROMETHEUS=1.8.2
-  - ANSIBLE='ansible>=2.5.0,<2.6.0' PROMETHEUS=2.2.1
+  - ANSIBLE='ansible>=2.3.0,<2.4.0'
+  - ANSIBLE='ansible>=2.4.0,<2.5.0'
   - ANSIBLE='ansible>=2.5.0,<2.6.0'
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `prometheus_version` | 2.2.1  | Prometheus package version. Also accepts `latest` as parameter. |
+| `prometheus_version` | 2.2.1  | Prometheus package version. Also accepts `latest` as parameter. Only prometheus 2.x is supported |
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
 | `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
 | `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -2,20 +2,10 @@
 - name: Run role
   hosts: all
   any_errors_fatal: true
-  pre_tasks:
-    - name: Set prometheus version from PROMETHEUS environment variable
-      set_fact:
-        prometheus_version: "{{ lookup('env', 'PROMETHEUS') | default('latest') }}"
-    - name: Set prometheus version to latest when not set previously
-      set_fact:
-        prometheus_version: "latest"
-      when: prometheus_version == ""
-    - name: Show prometheus version used in tests
-      debug:
-        var: prometheus_version
   roles:
     - ansible-prometheus
   vars:
+    prometheus_version: latest
     prometheus_config_dir: /opt/prom/etc
     prometheus_db_dir: /opt/prom/lib
     prometheus_web_listen_address: "127.0.0.1:9090"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,16 +2,5 @@
 - name: Run role
   hosts: all
   any_errors_fatal: true
-  pre_tasks:
-    - name: Set prometheus version from PROMETHEUS environment variable
-      set_fact:
-        prometheus_version: "{{ lookup('env', 'PROMETHEUS') | default('latest') }}"
-    - name: Set prometheus version to latest when not set previously
-      set_fact:
-        prometheus_version: "latest"
-      when: prometheus_version == ""
-    - name: Show prometheus version used in tests
-      debug:
-        var: prometheus_version
   roles:
     - ansible-prometheus

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: prometheus
     mode: 0640
-    validate: "{{ prometheus_rules_validator }}"
+    validate: "/usr/local/bin/promtool check rules %s"
   when:
     - prometheus_alertmanager_config != []
     - prometheus_alert_rules != []
@@ -20,7 +20,7 @@
     owner: root
     group: prometheus
     mode: 0640
-    validate: "{{ prometheus_rules_validator }}"
+    validate: "/usr/local/bin/promtool check rules %s"
   with_fileglob:
     - prometheus/rules/*
   notify:
@@ -34,7 +34,7 @@
     owner: root
     group: prometheus
     mode: 0640
-    validate: "{{ prometheus_config_validator }}"
+    validate: "/usr/local/bin/promtool check config %s"
   notify:
     - reload prometheus
 

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,16 +1,4 @@
 ---
-- name: Set validator commands for prometheus 2.x
-  set_fact:
-    prometheus_config_validator: "/usr/local/bin/promtool check config %s"
-    prometheus_rules_validator: "/usr/local/bin/promtool check rules %s"
-  when: prometheus_version is version_compare('2.0.0', '>=')
-
-- name: Set validator commands for prometheus 1.x
-  set_fact:
-    prometheus_config_validator: "/usr/local/bin/promtool check-config %s"
-    prometheus_rules_validator: "/usr/local/bin/promtool check-rules %s"
-  when: prometheus_version is version_compare('2.0.0', '<')
-
 - name: Check if extra config flags are duplicating ansible variables
   fail:
     msg: "Detected duplicate configuration entry. Please check your ansible variables and role README.md."
@@ -29,11 +17,6 @@
 - name: Set prometheus external metrics path
   set_fact:
     prometheus_metrics_path: "/{{ ( prometheus_web_external_url + '/metrics' ) | regex_replace('^(.*://)?(.*?)/') }}"
-
-- name: Set storage retention setting
-  set_fact:
-    prometheus_storage_retention: "{{ (prometheus_storage_retention | regex_search('\\d+') | int ) * 24 }}h0m0s"
-  when: prometheus_version is version_compare('2.0.0', '<')
 
 - name: Fail when prometheus_config_flags_extra duplicates parameters set by other variables
   fail:

--- a/templates/alert.rules.j2
+++ b/templates/alert.rules.j2
@@ -1,29 +1,5 @@
 # {{ ansible_managed }}
-{% if prometheus_version is version_compare('2.0.0', '>=') %}
 groups:
 - name: ansible managed alert rules
   rules:
   {{ prometheus_alert_rules | to_nice_yaml(indent=2) | indent(2,False) }}
-{% else %}
-{%   for alert in prometheus_alert_rules %}
-ALERT {{ alert.alert }}
-  IF {{ alert.expr }}
-{%     if 'for' in alert %}
-  FOR {{ alert.for }}
-{%     endif %}
-{%     if 'labels' in alert %}
-  LABELS {
-{%       for key, value in alert.labels.items() %}
-    {{ key }} = "{{ value }}"{{ "," if not loop.last else '' }}
-{%       endfor %}
-  }
-{%     endif %}
-{%     if 'annotations' in alert %}
-  ANNOTATIONS {
-{%       for key, value in alert.annotations.items() %}
-    {{ key }} = "{{ value }}"{{ "," if not loop.last else '' }}
-{%       endfor %}
-  }
-{%     endif %}
-{%   endfor %}
-{% endif %}

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -1,8 +1,3 @@
-{%- if prometheus_version is version_compare('2.0.0', '>=') %}
-{%- set pre = '-' %}
-{%- else %}
-{%- set pre = '' %}
-{%- endif %}
 # {{ ansible_managed }}
 [Unit]
 Description=Prometheus
@@ -15,12 +10,12 @@ User=prometheus
 Group=prometheus
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/prometheus \
-  {{ pre }}-config.file={{ prometheus_config_dir }}/prometheus.yml \
-  {{ pre }}-storage.{{ 'tsdb' if prometheus_version is version_compare('2.0.0', '>=') else 'local' }}.path={{ prometheus_db_dir }} \
-  {{ pre }}-storage.{{ 'tsdb' if prometheus_version is version_compare('2.0.0', '>=') else 'local' }}.retention={{ prometheus_storage_retention }} \
-  {{ pre }}-web.listen-address={{ prometheus_web_listen_address }} \
-  {{ pre }}-web.external-url={{ prometheus_web_external_url }}{% for flag, flag_value in prometheus_config_flags_extra.items() %}\
-  {{ pre }}-{{ flag }}={{ flag_value }} {% endfor %}
+  --config.file={{ prometheus_config_dir }}/prometheus.yml \
+  --storage.tsdb.path={{ prometheus_db_dir }} \
+  --storage.tsdb.retention={{ prometheus_storage_retention }} \
+  --web.listen-address={{ prometheus_web_listen_address }} \
+  --web.external-url={{ prometheus_web_external_url }}{% for flag, flag_value in prometheus_config_flags_extra.items() %}\
+  --{{ flag }}={{ flag_value }} {% endfor %}
 
 {% if http_proxy is defined %}
 Environment="HTTP_PROXY={{ http_proxy }}"{% if https_proxy is defined %} "HTTPS_PROXY={{ https_proxy }}{% endif %}"


### PR DESCRIPTION
I don't think there are people using our role AND prometheus 1.8.
Removing support for this version will simplify role and speed up travis tests by reducing test matrix to the same level as in other roles from Cloud Alchemy.

This is a breaking change.