### PR TITLE
specify file name for dest in get_url call

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
   become: false
   get_url:
     url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
+    dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
     checksum: "sha256:{{ prometheus_checksum }}"
   register: _download_archive
   until: _download_archive is succeeded


### PR DESCRIPTION
tested on ansible v2.5.3 and v2.4.4

The unarchive step failed as the get_url dest path ended up being /tmp/$UUID so unarchive could not find the source file. Not sure if there's something specific in my setup that caused this to fail.