### PR TITLE
Let prometheus rule_files config always be written

### DIFF
--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -17,10 +17,8 @@ remote_read:
   {{ prometheus_remote_read | to_nice_yaml(indent=2) | indent(2, False) }}
 {% endif %}
 
-{% if prometheus_alertmanager_config != [] and prometheus_alert_rules != [] %}
 rule_files:
   - {{ prometheus_config_dir }}/rules/*.rules
-{% endif %}
 
 {% if prometheus_alertmanager_config | length > 0 %}
 alerting:


### PR DESCRIPTION
To be able to add dynamic rules after applying role within some playbook task, the generic rule_files config path should always be written - even if there is no alertmanager or local rules defined.