### PR TITLE
fix prometheus_targets default value.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,12 +45,12 @@ prometheus_remote_read: []
 prometheus_external_labels:
   environment: "{{ ansible_fqdn | default(ansible_host) | default(inventory_hostname) }}"
 
-prometheus_targets:
-  node:
-    - targets:
-        - localhost:9100
-      labels:
-        env: test
+prometheus_targets: {}
+#  node:
+#    - targets:
+#        - localhost:9100
+#      labels:
+#        env: test
 
 prometheus_scrape_configs:
   - job_name: "prometheus"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -25,7 +25,6 @@ def test_directories(host, dirs):
     "/etc/prometheus/prometheus.yml",
     "/etc/prometheus/console_libraries/prom.lib",
     "/etc/prometheus/consoles/prometheus.html",
-    "/etc/prometheus/file_sd/node.yml",
     "/etc/systemd/system/prometheus.service",
     "/usr/local/bin/prometheus",
     "/usr/local/bin/promtool"


### PR DESCRIPTION
The `prometheus_targets` default value should be `{}`.