### PR TITLE
Allow role being run in check mode

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -66,6 +66,7 @@
 - name: Get systemd version
   shell: systemctl --version | awk '$1 == "systemd" {print $2}'
   changed_when: false
+  check_mode: false
   register: prometheus_systemd_version
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
By default, the "Get systemd version" would not run in check mode and thus the variable `prometheus_systemd_version` would not be set meaning that subsequent tasks that depend on that variable would fail with an error similar to the following:

```
TASK [cloudalchemy.prometheus : create systemd service unit] ********************************************************************************
fatal: [xxxxx]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'stdout'"}
```

With this change, the read-only task in question ("Get systemd version") is run even in check mode.