### PR TITLE
Allow empty value in config_flags_extra

### DIFF
--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -17,7 +17,7 @@ ExecStart=/usr/local/bin/prometheus \
   --web.console.templates={{ prometheus_config_dir }}/consoles \
   --web.listen-address={{ prometheus_web_listen_address }} \
   --web.external-url={{ prometheus_web_external_url }}{% for flag, flag_value in prometheus_config_flags_extra.items() %}\
-  --{{ flag }}={{ flag_value }} {% endfor %}
+  --{{ flag }}{% if flag_value %}={{ flag_value }}{% endif %} {% endfor %}
 
 PrivateTmp=true
 PrivateDevices=true


### PR DESCRIPTION
I wanted to enable administrative api endpoint using --web.enable-admin-api in prometheus service options but the operation failed because of the ansible mandatory "value" field.
the flag --web.enable-admin-api does not take any value.

According to https://prometheus.io/docs/operating/security/, I've made a fix to allow this