### PR TITLE
Updates to set systemd ulimit for files to infinity

### DIFF
--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -23,6 +23,7 @@ PrivateTmp=true
 PrivateDevices=true
 ProtectHome=true
 NoNewPrivileges=true
+LimitNOFILE=infinity
 {% if prometheus_systemd_version.stdout | int >= 231 %}
 ReadWritePaths={{ prometheus_db_dir }}
 {% else %}


### PR DESCRIPTION
If you have a lot of targets in your Prometheus configuration it will have a hard time writing WALs due to the system ulimit configuration. 

The use-case of this PR is that you have systems dedicated to just Prometheus, and instead of writing a playbook to finagle the system's ulimit settings, you make systemd manage that setting for you.

This PR might only be appropriate to our use-case though.