### PR TITLE
Fixed adding ansible comment in templates

### DIFF
--- a/templates/alert.rules.j2
+++ b/templates/alert.rules.j2
@@ -1,4 +1,5 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
+
 groups:
 - name: ansible managed alert rules
   rules:

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -1,4 +1,5 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
+
 [Unit]
 Description=Prometheus
 After=network.target

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -1,5 +1,5 @@
 #jinja2: trim_blocks: True, lstrip_blocks: True
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 # http://prometheus.io/docs/operating/configuration/
 
 global:


### PR DESCRIPTION
With {{ ansible_managed }} variable task: "configure prometheus" in configure.yml and starting prometheus service fails since mentioned variable adds comment without "#" marks and rows are treated as regular YAML. 