### PR TITLE
Add support for alert relabeling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,11 @@ prometheus_alertmanager_config: []
 #       - targets: ["127.0.0.1:9093"]
 #     proxy_url: "127.0.0.2"
 
+prometheus_alert_relabel_configs: []
+# prometheus_alert_relabel_configs:
+#   - action: labeldrop
+#     regex: replica
+
 prometheus_global:
   scrape_interval: 15s
   scrape_timeout: 10s

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -23,6 +23,9 @@
         static_configs:
           - targets: ["127.0.0.1:9090"]
         proxy_url: "127.0.0.2"
+    prometheus_alert_relabel_configs:
+      - action: labeldrop
+        regex: replica
     prometheus_global:
       scrape_interval: 3s
       scrape_timeout: 2s

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -24,6 +24,10 @@ rule_files:
 alerting:
   alertmanagers:
   {{ prometheus_alertmanager_config | to_nice_yaml(indent=2) | indent(2,False) }}
+  {% if prometheus_alert_relabel_configs | length > 0 %}
+  alert_relabel_configs:
+  {{ prometheus_alert_relabel_configs | to_nice_yaml(indent=2) | indent(2,False) }}
+  {% endif %}
 {% endif %}
 
 scrape_configs:


### PR DESCRIPTION
All other forms of relabeling (targets, metrics, remote write) are
already supported, but alert relabeling wasn't possible yet because it's
not part of the Prometheus Alertmanager configuration.

The most common use case for alert relabeling is dropping the "replica"
label of an HA Prometheus pair, so I chose that as an example.