### PR TITLE
Add clarification surrounding when the .rules file is copied & where it goes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `prometheus_targets` | {} | Targets which will be scraped. Better example is provided in our [demo site](https://github.com/cloudalchemy/demo-site/blob/2a8a56fc10ce613d8b08dc8623230dace6704f9a/group_vars/all/vars#L8) |
 | `prometheus_scrape_configs` | [defaults/main.yml#L58](https://github.com/cloudalchemy/ansible-prometheus/blob/ff7830d06ba57be1177f2b6fca33a4dd2d97dc20/defaults/main.yml#L47) | Prometheus scrape jobs provided in same format as in [official docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) |
 | `prometheus_config_file` | "prometheus.yml.j2" | Variable used to provide custom prometheus configuration file in form of ansible template |
-| `prometheus_alert_rules` | [defaults/main.yml#L58](https://github.com/cloudalchemy/ansible-prometheus/blob/ff7830d06ba57be1177f2b6fca33a4dd2d97dc20/defaults/main.yml#L58) | Full list of alerting rules which will be copied to `{{ prometheus_config_dir }}/rules/basic.rules`. Alerting rules can be also provided by other files located in `{{ prometheus_config_dir }}/rules/` which have `*.rules` extension |
+| `prometheus_alert_rules` | [defaults/main.yml#L58](https://github.com/cloudalchemy/ansible-prometheus/blob/ff7830d06ba57be1177f2b6fca33a4dd2d97dc20/defaults/main.yml#L58) | Full list of alerting rules which will be copied to `{{ prometheus_config_dir }}/rules/ansible_managed.rules`. Alerting rules can be also provided by other files located in `{{ prometheus_config_dir }}/rules/` which have `*.rules` extension |
 
 ### Relation between `prometheus_scrape_configs` and `prometheus_targets`
 

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -35,6 +35,13 @@
   #  when: not item | basename | splitext | difference(['.yml']) | join('') in prometheus_targets.keys()
   with_dict: "{{ prometheus_targets }}"
 
+- name: Fail when prometheus_alertmanager_config is empty, but prometheus_alert_rules is specified
+  debug:
+    msg: "There's no use in defining alerting rules if you're not going to use them! Be sure to specify a prometheus_alertmanager_config in defaults/main.yml if you're going to define prometheus_alert_rules"
+  when:
+    - prometheus_alertmanager_config == []
+    - prometheus_alert_rules != []
+
 - block:
     - name: Get latest release
       uri:


### PR DESCRIPTION
This PR adds a debug statement to warn users that their rules configuration won't be copied if they didn't provide a `prometheus_alertmanager_config` value but DID provide a `prometheus_alert_rules` value in defaults/main.yml

Also updates the README to reflect that the .rules file gets saved to ansible_managed.rules rather than basic.rules

Fixes #148