### PR TITLE
Fix running Dry Mode and improved tag usage

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,6 +47,7 @@
   delay: 2
   # run_once: true # <-- this canfalset be set due to multi-arch support
   delegate_to: localhost
+  check_mode: no
 
 - name: unpack prometheus binaries
   become: false
@@ -55,7 +56,7 @@
     dest: "/tmp"
     creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/prometheus"
   delegate_to: localhost
-  check_mode: false
+  check_mode: no
 
 - name: propagate prometheus and promtool binaries
   copy:
@@ -67,7 +68,6 @@
   with_items:
     - prometheus
     - promtool
-  check_mode: false
   notify:
     - restart prometheus
 
@@ -81,7 +81,6 @@
   with_items:
     - console_libraries
     - consoles
-  check_mode: false
   notify:
     - restart prometheus
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,7 +47,7 @@
   delay: 2
   # run_once: true # <-- this canfalset be set due to multi-arch support
   delegate_to: localhost
-  check_mode: no
+  check_mode: false
 
 - name: unpack prometheus binaries
   become: false
@@ -56,7 +56,7 @@
     dest: "/tmp"
     creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/prometheus"
   delegate_to: localhost
-  check_mode: no
+  check_mode: false
 
 - name: propagate prometheus and promtool binaries
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,15 @@
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:
-    - always
+    - configure
+    - install
+    - run
 
 - include: preflight.yml
   tags:
-    - always
+    - configure
+    - install
+    - run
 
 - include: install.yml
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,25 +5,25 @@
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:
-    - configure
-    - install
-    - run
+    - prometheus_configure
+    - prometheus_install
+    - prometheus_run
 
 - include: preflight.yml
   tags:
-    - configure
-    - install
-    - run
+    - prometheus_configure
+    - prometheus_install
+    - prometheus_run
 
 - include: install.yml
   become: true
   tags:
-    - install
+    - prometheus_install
 
 - include: configure.yml
   become: true
   tags:
-    - configure
+    - prometheus_configure
 
 - name: ensure prometheus service is started and enabled
   become: true
@@ -33,4 +33,4 @@
     state: started
     enabled: true
   tags:
-    - run
+    - prometheus_run

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
-molecule>=2.15.0
-docker
 ansible-lint>=3.4.0
-testinfra>=1.7.0
+docker
 jmespath
+molecule>=2.15.0
+pytest==3.9.3
+testinfra>=1.7.0


### PR DESCRIPTION
- Fixed dry_run (`--check`) mode. By default it was failing on task _unpack prometheus binaries_ as binaries were not downloaded. This changes are done locally, so not danger
- Fixed value of `check_mode` - according to documentation it only accepts values `yes/no`, not `false`. 
- Replaced tags `always` with list of all tags, used in module. This makes including role much easier, as it runs only, when asked, not ie. update accidentally Prometheus, when running different tags. 
- Prepended tag names with `prometheus` to have mor unique tags, than current one.