### PR TITLE
make Prometheus' home directory configurable

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,15 +12,16 @@
     shell: "/sbin/nologin"
     group: prometheus
     createhome: false
-    home: /tmp
+    home: "{{ prometheus_db_dir }}"
 
 - name: create prometheus data directory
   file:
     path: "{{ prometheus_db_dir }}"
     state: directory
+    mode: 0755
     owner: prometheus
     group: prometheus
-    mode: 0755
+    recurse: true
 
 - name: create prometheus configuration directories
   file:


### PR DESCRIPTION
We're not using GCE, and making `/tmp` (#153) owned by a specific user is generally a bad idea. This introduced a config variable to make this configurable. It might even help solve #166.