### PR TITLE
Reuse `prometheus_db_dir` as prometheus user home directory

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,7 +12,7 @@
     shell: "/sbin/nologin"
     group: prometheus
     createhome: false
-    home: /tmp
+    home: "{{ prometheus_db_dir }}"
 
 - name: create prometheus data directory
   file:


### PR DESCRIPTION
Alternative take on #169

Closes #169
Closes #166