### PR TITLE
Make prometheus user owner of prometheus folders

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,7 +28,7 @@
     state: directory
     owner: root
     group: prometheus
-    mode: 0750
+    mode: 0770
   with_items:
     - "{{ prometheus_config_dir }}"
     - "{{ prometheus_config_dir }}/conf.d"


### PR DESCRIPTION
Change so prometheus user is the owner of its configurations folders.
This to have other tooling generating service discovery files that does
not need to be running as root user.

Also I think there is more correct to let promethus own its folders and
files when we have user and group created for prometheus.