### PR TITLE
prometheus.service.j2: stop using tests as filters

### DIFF
--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -13,7 +13,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/prometheus \
   --config.file={{ prometheus_config_dir }}/prometheus.yml \
   --storage.tsdb.path={{ prometheus_db_dir }} \
-{% if prometheus_version | version_compare('2.7.0', '>=') %}
+{% if prometheus_version is version_compare('2.7.0', '>=') %}
   --storage.tsdb.retention.time={{ prometheus_storage_retention }} \
   --storage.tsdb.retention.size={{ prometheus_storage_retention_size }} \
 {% else %}


### PR DESCRIPTION
This removes the following deprecation warning: `[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|version_compare` use `result is version_compare`. This feature will be removed in version 2.9. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.`