### PR TITLE
set go_arch as a var instead of calculating it during task execution

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,8 +38,8 @@
 - name: download prometheus binary to local folder
   become: false
   get_url:
-    url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+    dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
     checksum: "sha256:{{ prometheus_checksum }}"
   register: _download_archive
   until: _download_archive is succeeded
@@ -52,15 +52,15 @@
 - name: unpack prometheus binaries
   become: false
   unarchive:
-    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "/tmp"
-    creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/prometheus"
+    creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/prometheus"
   delegate_to: localhost
   check_mode: false
 
 - name: propagate prometheus and promtool binaries
   copy:
-    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/{{ item }}"
+    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}"
     dest: "/usr/local/bin/{{ item }}"
     mode: 0755
     owner: root
@@ -73,7 +73,7 @@
 
 - name: propagate console templates
   copy:
-    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/{{ item }}/"
+    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}/"
     dest: "{{ prometheus_config_dir }}/{{ item }}/"
     mode: 0644
     owner: root

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -94,9 +94,9 @@
         prometheus_version: "{{ _latest_release.json.tag_name[1:] }}"
   when: prometheus_version == "latest"
 
-- name: "Get checksum for {{ go_arch_map[ansible_architecture] | default(ansible_architecture) }} architecture"
+- name: "Get checksum for {{ go_arch }} architecture"
   set_fact:
     prometheus_checksum: "{{ item.split(' ')[0] }}"
   with_items:
     - "{{ lookup('url', 'https://github.com/prometheus/prometheus/releases/download/v' + prometheus_version + '/sha256sums.txt', wantlist=True) | list }}"
-  when: "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"
+  when: "('linux-' + go_arch + '.tar.gz') in item"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,3 +5,5 @@ go_arch_map:
   aarch64: 'arm64'
   armv7l: 'armv7'
   armv6l: 'armv6'
+
+go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"


### PR DESCRIPTION
This mechanism is already used in [cloudalchemy/ansible-node-exporter](https://github.com/cloudalchemy/ansible-node-exporter)