### PR TITLE
Update label for CriticalDiskSpace alert expression.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,7 +108,7 @@ prometheus_alert_rules:
       description: "{% raw %}{{ $labels.instance }} has Critical Memory Usage more than 5 minutes.{% endraw %}"
       summary: "{% raw %}Instance {{ $labels.instance }} has Critical Memory Usage{% endraw %}"
   - alert: CriticalDiskSpace
-    expr: 'node_filesystem_free_bytes{mountpoint!~"^/(snap|run)(/.*|$)",job="node"} / node_filesystem_size_bytes{job="node"} < 0.1'
+    expr: 'node_filesystem_free_bytes{fstype!~"(tmpfs|squashfs|fuse.*)",job="node"} / node_filesystem_size_bytes{job="node"} < 0.1'
     for: 4m
     labels:
       severity: critical

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,7 +108,7 @@ prometheus_alert_rules:
       description: "{% raw %}{{ $labels.instance }} has Critical Memory Usage more than 5 minutes.{% endraw %}"
       summary: "{% raw %}Instance {{ $labels.instance }} has Critical Memory Usage{% endraw %}"
   - alert: CriticalDiskSpace
-    expr: 'node_filesystem_free_bytes{fstype!~"(tmpfs|squashfs|fuse.*)",job="node"} / node_filesystem_size_bytes{job="node"} < 0.1'
+    expr: 'node_filesystem_free_bytes{mountpoint!~"^/run(/.*|$)",fstype!~"(squashfs|fuse.*)",job="node"} / node_filesystem_size_bytes{job="node"} < 0.1'
     for: 4m
     labels:
       severity: critical

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,7 +108,7 @@ prometheus_alert_rules:
       description: "{% raw %}{{ $labels.instance }} has Critical Memory Usage more than 5 minutes.{% endraw %}"
       summary: "{% raw %}Instance {{ $labels.instance }} has Critical Memory Usage{% endraw %}"
   - alert: CriticalDiskSpace
-    expr: 'node_filesystem_free_bytes{job="node",filesystem!~"^/run(/|$)"} / node_filesystem_size_bytes{job="node"} < 0.1'
+    expr: 'node_filesystem_free_bytes{mountpoint!~"^/(snap|run)(/.*|$)",job="node"} / node_filesystem_size_bytes{job="node"} < 0.1'
     for: 4m
     labels:
       severity: critical


### PR DESCRIPTION
Label has changed from `filesystem` to `mountpoint` in newer versions of `node_exporter`

Also added `/snap` mount points to be ignored - squashfs filesystems used on Ubuntu by snapd.

Fixes #201 