### PR TITLE
add watchdog and clock skew alerts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,6 +83,18 @@ prometheus_static_targets_files:
   - prometheus/targets/*.json
 
 prometheus_alert_rules:
+  - alert: Watchdog
+    expr: vector(1)
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: 'This is an alert meant to ensure that the entire alerting pipeline is functional.
+        This alert is always firing, therefore it should always be firing in Alertmanager
+        and always fire against a receiver. There are integrations with various notification
+        mechanisms that send a notification when this alert is not firing. For example the
+        "DeadMansSnitch" integration in PagerDuty.'
+      summary: 'Ensure entire alerting pipeline is functional'
   - alert: InstanceDown
     expr: "up == 0"
     for: 5m
@@ -122,3 +134,11 @@ prometheus_alert_rules:
     annotations:
       description: "{% raw %}{{ $labels.instance }} requires a reboot.{% endraw %}"
       summary: "{% raw %}Instance {{ $labels.instance }} - reboot required{% endraw %}"
+  - alert: ClockSkewDetected
+    expr: 'abs(node_timex_offset_seconds) * 1000 > 30'
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: "{% raw %}Clock skew detected on {{ $labels.instance }}. Ensure NTP is configured correctly on this host.{% endraw %}"
+      summary: "{% raw %}Instance {{ $labels.instance }} - Clock skew detected{% endraw %}"


### PR DESCRIPTION
Adding watchdog alert as a default mostly for two reasons:
- it is a good practice to have such alarm
- it will simplify demo site installation and show there a constantly firing alert

I believe adding constantly firing alert and an instance of random_exporter (already added) makes demo.cloudalchemy.org closer to being adopted as an official prometheus demo site

/CC: @SuperQ 