### PR TITLE
increase systemd service security restrictions

### DIFF
--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -26,7 +26,7 @@ ExecStart=/usr/local/bin/prometheus \
   --{{ flag }}{% if flag_value %}={{ flag_value }}{% endif %} {% endfor %}
 
 CapabilityBoundingSet=CAP_SET_UID
-LimitNOFILE=infinity
+LimitNOFILE=65000
 LockPersonality=true
 NoNewPrivileges=true
 MemoryDenyWriteExecute=true

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -25,21 +25,30 @@ ExecStart=/usr/local/bin/prometheus \
   --web.external-url={{ prometheus_web_external_url }}{% for flag, flag_value in prometheus_config_flags_extra.items() %}\
   --{{ flag }}{% if flag_value %}={{ flag_value }}{% endif %} {% endfor %}
 
-PrivateTmp=true
-PrivateDevices=true
-ProtectHome=true
-NoNewPrivileges=true
+CapabilityBoundingSet=CAP_SET_UID
 LimitNOFILE=infinity
+LockPersonality=true
+NoNewPrivileges=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectHome=true
+RemoveIPC=true
+RestrictSUIDSGID=true
+#SystemCallFilter=@signal @timer
+
 {% if prometheus_systemd_version | int >= 231 %}
 ReadWritePaths={{ prometheus_db_dir }}
 {% else %}
 ReadWriteDirectories={{ prometheus_db_dir }}
 {% endif %}
+
 {% if prometheus_systemd_version | int >= 232 %}
-ProtectSystem=strict
+PrivateUsers=true
 ProtectControlGroups=true
 ProtectKernelModules=true
 ProtectKernelTunables=true
+ProtectSystem=strict
 {% else %}
 ProtectSystem=full
 {% endif %}


### PR DESCRIPTION
I ran `systemd-analyze security` and result wasn't satisfying as prometheus.service got score 7/10 (10/10 is the most insecure). This PR is an attempt at increasing security of systemd service file used by prometheus.

Systemd will just omit options which it cannot understand so this will have much better security when used with newer systemd versions.

Additionally I alphabetically sorted options.

Over next days I will do similar change for other monitoring components. It would be also nice to do something similar in upstream grafana systemd file.

@SuperQ do you know what [`SystemCallFilter`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#System%20Call%20Filtering) we can assign?