### PR TITLE
makes install dir configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `prometheus_version` | 2.10.0 | Prometheus package version. Also accepts `latest` as parameter. Only prometheus 2.x is supported |
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
 | `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
+| `prometheus_install_dir` | /usr/local/bin | Path to directory where prometheus binaries will be installed |
 | `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |
 | `prometheus_web_external_url` | "" | External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus` |
 | `prometheus_storage_retention` | "30d" | Data retention period |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ prometheus_version: 2.11.0
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus
+prometheus_install_dir: /usr/local/bin
 
 prometheus_web_listen_address: "0.0.0.0:9090"
 prometheus_web_external_url: ''

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: prometheus
     mode: 0640
-    validate: "/usr/local/bin/promtool check rules %s"
+    validate: "{{ prometheus_install_dir }}/promtool check rules %s"
   when:
     - prometheus_alertmanager_config != []
     - prometheus_alert_rules != []
@@ -20,7 +20,7 @@
     owner: root
     group: prometheus
     mode: 0640
-    validate: "/usr/local/bin/promtool check rules %s"
+    validate: "{{ prometheus_install_dir }}/promtool check rules %s"
   with_fileglob: "{{ prometheus_alert_rules_files }}"
   notify:
     - reload prometheus
@@ -33,7 +33,7 @@
     owner: root
     group: prometheus
     mode: 0640
-    validate: "/usr/local/bin/promtool check config %s"
+    validate: "{{ prometheus_install_dir }}/promtool check config %s"
   notify:
     - reload prometheus
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,6 +35,14 @@
     - "{{ prometheus_config_dir }}/rules"
     - "{{ prometheus_config_dir }}/file_sd"
 
+- name: create prometheus installation directory
+  file:
+    path: "{{ prometheus_install_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
 - name: download prometheus binary to local folder
   become: false
   get_url:
@@ -61,7 +69,7 @@
 - name: propagate prometheus and promtool binaries
   copy:
     src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}"
-    dest: "/usr/local/bin/{{ item }}"
+    dest: "{{ prometheus_install_dir }}/{{ item }}"
     mode: 0755
     owner: root
     group: root

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -10,7 +10,7 @@ Environment="GOMAXPROCS={{ ansible_processor_vcpus|default(ansible_processor_cou
 User=prometheus
 Group=prometheus
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/prometheus \
+ExecStart={{ prometheus_install_dir }}/prometheus \
   --config.file={{ prometheus_config_dir }}/prometheus.yml \
   --storage.tsdb.path={{ prometheus_db_dir }} \
 {% if prometheus_version is version_compare('2.7.0', '>=') %}


### PR DESCRIPTION
The install dir was hard-coded to `/usr/local/bin`. This commit adds `prometheus_install_dir` to allow this to change. It defaults to the old hard-coded value to enable full backwards compatibility.

## Background

On one of my target systems, for *historical reasons*, a networked storage is mounted to `/usr/local`. I don't really want to install prometheus to a networked storage, because if there are network issues, prometheus would crash. For this reason, I would like to have the possibility to change the installation directory.