### PR TITLE
Making the prometheus_binary_location variable

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
 - name: download prometheus binary to local folder
   become: false
   get_url:
-    url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+    url: "{{ prometheus_binary_location }}/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
     checksum: "sha256:{{ prometheus_checksum }}"
   register: _download_archive

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -97,5 +97,5 @@
   set_fact:
     prometheus_checksum: "{{ item.split(' ')[0] }}"
   with_items:
-    - "{{ lookup('url', 'https://github.com/prometheus/prometheus/releases/download/v' + prometheus_version + '/sha256sums.txt', wantlist=True) | list }}"
+    - "{{ lookup('url', prometheus_binary_location + '/v' + prometheus_version + '/sha256sums.txt', wantlist=True) | list }}"
   when: "('linux-' + go_arch + '.tar.gz') in item"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,5 @@ go_arch_map:
   armv6l: 'armv6'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+
+prometheus_binary_location: "https://github.com/prometheus/prometheus/releases/download"


### PR DESCRIPTION
The binary can't be downloaded when there is only a local storage solution.