### PR TITLE
add option to propagate binaries without access to internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `prometheus_version` | 2.14.0 | Prometheus package version. Also accepts `latest` as parameter. Only prometheus 2.x is supported |
+| `prometheus_binaries_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `prometheus` AND `promtool` binaries are stored on host on which ansible is ran. This overrides `prometheus_version` parameter |
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
 | `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
 | `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 prometheus_version: 2.14.0
+prometheus_binary_local_dir: ''
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -5,6 +5,7 @@
   roles:
     - ansible-prometheus
   vars:
+    prometheus_binary_local_dir: '/tmp/prometheus-linux-amd64'
     prometheus_config_dir: /opt/prom/etc
     prometheus_db_dir: /opt/prom/lib
     prometheus_web_listen_address: "127.0.0.1:9090"

--- a/molecule/alternative/prepare.yml
+++ b/molecule/alternative/prepare.yml
@@ -1,5 +1,37 @@
 ---
 - name: Prepare
-  hosts: all
+  hosts: localhost
   gather_facts: false
-  tasks: []
+  vars:
+    # Version seeds to be specified here as molecule doesn't have access to ansible_version at this stage
+    version: 2.14.0
+  tasks:
+    - name: download prometheus binary to local folder
+      become: false
+      get_url:
+        url: "https://github.com/prometheus/prometheus/releases/download/v{{ version }}/prometheus-{{ version }}.linux-amd64.tar.gz"
+        dest: "/tmp/prometheus-{{ version }}.linux-amd64.tar.gz"
+      register: _download_archive
+      until: _download_archive is succeeded
+      retries: 5
+      delay: 2
+      run_once: true
+      check_mode: false
+
+    - name: unpack prometheus binaries
+      become: false
+      unarchive:
+        src: "/tmp/prometheus-{{ version }}.linux-amd64.tar.gz"
+        dest: "/tmp"
+        creates: "/tmp/prometheus-{{ version }}.linux-amd64/prometheus"
+      run_once: true
+      check_mode: false
+
+    - name: link to prometheus binaries directory
+      become: false
+      file:
+        src: "/tmp/prometheus-{{ version }}.linux-amd64"
+        dest: "/tmp/prometheus-linux-amd64"
+        state: link
+      run_once: true
+      check_mode: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,32 +35,60 @@
     - "{{ prometheus_config_dir }}/rules"
     - "{{ prometheus_config_dir }}/file_sd"
 
-- name: download prometheus binary to local folder
-  become: false
-  get_url:
-    url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
-    dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
-    checksum: "sha256:{{ prometheus_checksum }}"
-  register: _download_archive
-  until: _download_archive is succeeded
-  retries: 5
-  delay: 2
-  # run_once: true # <-- this cannot be set due to multi-arch support
-  delegate_to: localhost
-  check_mode: false
+- block:
+    - name: download prometheus binary to local folder
+      become: false
+      get_url:
+        url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+        checksum: "sha256:{{ prometheus_checksum }}"
+      register: _download_archive
+      until: _download_archive is succeeded
+      retries: 5
+      delay: 2
+      # run_once: true # <-- this cannot be set due to multi-arch support
+      delegate_to: localhost
+      check_mode: false
 
-- name: unpack prometheus binaries
-  become: false
-  unarchive:
-    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
-    dest: "/tmp"
-    creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/prometheus"
-  delegate_to: localhost
-  check_mode: false
+    - name: unpack prometheus binaries
+      become: false
+      unarchive:
+        src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp"
+        creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/prometheus"
+      delegate_to: localhost
+      check_mode: false
 
-- name: propagate prometheus and promtool binaries
+    - name: propagate official prometheus and promtool binaries
+      copy:
+        src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}"
+        dest: "/usr/local/bin/{{ item }}"
+        mode: 0755
+        owner: root
+        group: root
+      with_items:
+        - prometheus
+        - promtool
+      notify:
+        - restart prometheus
+
+    - name: propagate official console templates
+      copy:
+        src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}/"
+        dest: "{{ prometheus_config_dir }}/{{ item }}/"
+        mode: 0644
+        owner: root
+        group: root
+      with_items:
+        - console_libraries
+        - consoles
+      notify:
+        - restart prometheus
+  when: prometheus_binary_local_dir | length == 0
+
+- name: propagate locally distributed prometheus and promtool binaries
   copy:
-    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}"
+    src: "{{ prometheus_binary_local_dir }}/{{ item }}"
     dest: "/usr/local/bin/{{ item }}"
     mode: 0755
     owner: root
@@ -68,19 +96,7 @@
   with_items:
     - prometheus
     - promtool
-  notify:
-    - restart prometheus
-
-- name: propagate console templates
-  copy:
-    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}/"
-    dest: "{{ prometheus_config_dir }}/{{ item }}/"
-    mode: 0644
-    owner: root
-    group: root
-  with_items:
-    - console_libraries
-    - consoles
+  when: prometheus_binary_local_dir | length > 0
   notify:
     - restart prometheus
 

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -91,11 +91,15 @@
     - name: "Set prometheus version to {{ _latest_release.json.tag_name[1:] }}"
       set_fact:
         prometheus_version: "{{ _latest_release.json.tag_name[1:] }}"
-  when: prometheus_version == "latest"
+  when:
+    - prometheus_version == "latest"
+    - prometheus_binary_local_path | length == 0
 
 - name: "Get checksum for {{ go_arch }} architecture"
   set_fact:
     prometheus_checksum: "{{ item.split(' ')[0] }}"
   with_items:
     - "{{ lookup('url', 'https://github.com/prometheus/prometheus/releases/download/v' + prometheus_version + '/sha256sums.txt', wantlist=True) | list }}"
-  when: "('linux-' + go_arch + '.tar.gz') in item"
+  when:
+    - "('linux-' + go_arch + '.tar.gz') in item"
+    - prometheus_binary_local_dir | length == 0


### PR DESCRIPTION
Same as https://github.com/cloudalchemy/ansible-alertmanager/pull/83 but for prometheus.