### PR TITLE
Add CentOS/CentOS-8 support

### DIFF
--- a/vars/centos-8.yml
+++ b/vars/centos-8.yml
@@ -1,0 +1,4 @@
+---
+prometheus_selinux_packages:
+  - python3-libselinux
+  - python3-policycoreutils

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -1,0 +1,4 @@
+---
+prometheus_selinux_packages:
+  - libselinux-python
+  - policycoreutils-python


### PR DESCRIPTION
Installing on CentOS 8 failed as the ansible_distribution was not being matched.
Adding centos.yml and centos-8.yml with same content as redhat* vars files fixed this.