### PR TITLE
Make download and unpack steps idempotent

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -49,6 +49,7 @@
       # run_once: true # <-- this cannot be set due to multi-arch support
       delegate_to: localhost
       check_mode: false
+      changed_when: false
 
     - name: unpack prometheus binaries
       become: false
@@ -58,6 +59,7 @@
         creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/prometheus"
       delegate_to: localhost
       check_mode: false
+      changed_when: false
 
     - name: propagate official prometheus and promtool binaries
       copy:


### PR DESCRIPTION
For now theses two task:
- `download prometheus binary to local folder`
- `unpack prometheus binaries`
aren't indempotent.

They randomly are in changed state because theses steps are executed locally (`delegate_to: localhost`).

With the `changed_when: false` they will no longer be in changed state (they still can be in fail mode, if anything goes wrong)