### PR TITLE
Switch user login shell to /usr/sbin/nologin

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,7 +9,7 @@
   user:
     name: prometheus
     system: true
-    shell: "/sbin/nologin"
+    shell: "/usr/sbin/nologin"
     group: prometheus
     createhome: false
     home: "{{ prometheus_db_dir }}"


### PR DESCRIPTION
tasks: debian-based distros doesn't have /sbin/nologin, but /usr/sbin/nologin is available on RHEL family systems

Issue found during compatibility testing with dev-sec.os-hardening role.