### PR TITLE
Add binary install directory

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: root
     group: prometheus
     mode: 0640
-    validate: "/usr/local/bin/promtool check rules %s"
+    validate: "{{ _prometheus_binary_install_dir }}/promtool check rules %s"
   when:
     - prometheus_alert_rules != []
   notify:
@@ -19,7 +19,7 @@
     owner: root
     group: prometheus
     mode: 0640
-    validate: "/usr/local/bin/promtool check rules %s"
+    validate: "{{ _prometheus_binary_install_dir }}/promtool check rules %s"
   with_fileglob: "{{ prometheus_alert_rules_files }}"
   notify:
     - reload prometheus
@@ -32,7 +32,7 @@
     owner: root
     group: prometheus
     mode: 0640
-    validate: "/usr/local/bin/promtool check config %s"
+    validate: "{{ _prometheus_binary_install_dir }}/promtool check config %s"
   notify:
     - reload prometheus
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,6 +22,13 @@
     group: prometheus
     mode: 0755
 
+- name: create prometheus binary install directory
+  file:
+    path: "{{ _prometheus_binary_install_dir }}"
+    state: directory
+    owner: root
+    group: root
+
 - name: create prometheus configuration directories
   file:
     path: "{{ item }}"
@@ -62,7 +69,7 @@
     - name: propagate official prometheus and promtool binaries
       copy:
         src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}"
-        dest: "/usr/local/bin/{{ item }}"
+        dest: "{{ _prometheus_binary_install_dir }}/{{ item }}"
         mode: 0755
         owner: root
         group: root
@@ -89,7 +96,7 @@
 - name: propagate locally distributed prometheus and promtool binaries
   copy:
     src: "{{ prometheus_binary_local_dir }}/{{ item }}"
-    dest: "/usr/local/bin/{{ item }}"
+    dest: "{{ _prometheus_binary_install_dir }}/{{ item }}"
     mode: 0755
     owner: root
     group: root

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -10,7 +10,7 @@ Environment="GOMAXPROCS={{ ansible_processor_vcpus|default(ansible_processor_cou
 User=prometheus
 Group=prometheus
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/prometheus \
+ExecStart={{ _prometheus_binary_install_dir }}/prometheus \
   --config.file={{ prometheus_config_dir }}/prometheus.yml \
   --storage.tsdb.path={{ prometheus_db_dir }} \
 {% if prometheus_version is version_compare('2.7.0', '>=') %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,4 @@ go_arch_map:
   armv6l: 'armv6'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+_prometheus_binary_install_dir: '/usr/local/bin'


### PR DESCRIPTION
Binaries are currently droped on /usr/local/bin

This commit add `prometheus_binary_install_dir` variable where user can
change the binary destination to `/opt/bin` for example.