### PR TITLE
Do not manage system directory

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,13 +22,6 @@
     group: prometheus
     mode: 0755
 
-- name: create prometheus binary install directory
-  file:
-    path: "{{ _prometheus_binary_install_dir }}"
-    state: directory
-    owner: root
-    group: root
-
 - name: create prometheus configuration directories
   file:
     path: "{{ item }}"


### PR DESCRIPTION
By default node_exporter binary is placed in `/usr/local/bin` which causes removed task to manage this directory. Such "feature" is out of scope of this role and can cause problems in some deployment scenarios.\

This is a follow-up to #259