### PR TITLE
Clean rules and service discover file before new deployment

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,42 @@
 ---
+- name: get clean rules file
+  find:
+    paths: "{{ prometheus_config_dir }}/rules/"
+    patterns: "*.rules"
+    owner: root
+    group: prometheus
+    mode: 0640
+    # use:regex: true
+  register: wildcard_files_to_delete
+
+- name: remove clean rules file
+  file:
+    path: "{{ item.path }}"
+    state: absent
+    owner: root
+    group: prometheus
+    mode: 0640
+  with_items: "{{ wildcard_files_to_delete.files }}"
+
+- name: get clean service discovery file
+  find:
+    paths: "{{ prometheus_config_dir }}/file_sd/"
+    patterns: "*.yaml"
+    owner: root
+    group: prometheus
+    mode: 0640
+    # use:regex: true
+  register: wildcard_files_to_delete
+
+- name: remove clean service discovery file
+  file:
+    path: "{{ item.path }}"
+    state: absent
+    owner: root
+    group: prometheus
+    mode: 0640
+  with_items: "{{ wildcard_files_to_delete.files }}"
+
 - name: alerting rules file
   template:
     src: "alert.rules.j2"


### PR DESCRIPTION
There was a problem when I use this playbook. The problem was when I add rules file in **{{ prometheus_config_dir }}/rules/**, the targeted rules files are copied successfully into target, but when I remove a file from **{{ prometheus_config_dir }}/rules/** the files doesn't remove from target. The problem was also in service discovery. 

I add 4 tasks into configure.yml file. It cleans those directories before every time you run the script. 