### PR TITLE
improve path_prefix example in defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ prometheus_config_flags_extra: {}
 prometheus_alertmanager_config: []
 # prometheus_alertmanager_config:
 #   - scheme: https
-#     path_prefix: /alertmanager
+#     path_prefix: alertmanager/
 #     basic_auth:
 #       username: user
 #       password: pass


### PR DESCRIPTION
Hello, 
thanks for this awesome role!

For me "path_prefix:" needed to be "alertmanager/" instead of "/alertmanager". 

See also:
https://github.com/prometheus/alertmanager/issues/528#issuecomment-369077042

Maybe you might consider updating the example in the defaults.

Thank you!