### PR TITLE
Add an option to not download binaries

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 prometheus_version: 2.17.1
 prometheus_binary_local_dir: ''
+prometheus_binary_download: true
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -84,7 +84,9 @@
         - consoles
       notify:
         - restart prometheus
-  when: prometheus_binary_local_dir | length == 0
+  when:
+    - prometheus_binary_local_dir | length == 0
+    - prometheus_binary_download
 
 - name: propagate locally distributed prometheus and promtool binaries
   copy:
@@ -96,7 +98,9 @@
   with_items:
     - prometheus
     - promtool
-  when: prometheus_binary_local_dir | length > 0
+  when:
+    - prometheus_binary_local_dir | length > 0
+    - prometheus_binary_download
   notify:
     - restart prometheus
 


### PR DESCRIPTION
Hello,

For my needs I created debian package with prometheus inside.
So I need an ansible role to configure prometheus but the installation is done through package management tool.
I added an option in this role `prometeus_binary_download` to disable tasks regarding the downloads.
This option is set to `true` by default to not change the current behavior of this role.

Thanks.