### PR TITLE
Fix version_compare filter deprecation

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -124,7 +124,7 @@
   retries: 5
   delay: 2
   when:
-    - ansible_version.full is version_compare('2.4', '>=')
+    - ansible_version.full is version('2.4', '>=')
     - ansible_selinux.status == "enabled"
 
 - name: Allow prometheus to bind to port in SELinux
@@ -134,5 +134,5 @@
     setype: http_port_t
     state: present
   when:
-    - ansible_version.full is version_compare('2.4', '>=')
+    - ansible_version.full is version('2.4', '>=')
     - ansible_selinux.status == "enabled"

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -13,7 +13,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ _prometheus_binary_install_dir }}/prometheus \
   --config.file={{ prometheus_config_dir }}/prometheus.yml \
   --storage.tsdb.path={{ prometheus_db_dir }} \
-{% if prometheus_version is version_compare('2.7.0', '>=') %}
+{% if prometheus_version is version('2.7.0', '>=') %}
   --storage.tsdb.retention.time={{ prometheus_storage_retention }} \
   --storage.tsdb.retention.size={{ prometheus_storage_retention_size }} \
 {% else %}


### PR DESCRIPTION
version_compare was deprecated in ansible version 2.5.0 and removed in
version 2.9.0. It has been renamed to `version`.

This patch simply uses the new name of the filter instead of the old
one.