### PR TITLE
Add rule files managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `prometheus_targets` | {} | Targets which will be scraped. Better example is provided in our [demo site](https://github.com/cloudalchemy/demo-site/blob/2a8a56fc10ce613d8b08dc8623230dace6704f9a/group_vars/all/vars#L8) |
 | `prometheus_scrape_configs` | [defaults/main.yml#L58](https://github.com/cloudalchemy/ansible-prometheus/blob/ff7830d06ba57be1177f2b6fca33a4dd2d97dc20/defaults/main.yml#L47) | Prometheus scrape jobs provided in same format as in [official docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) |
 | `prometheus_config_file` | "prometheus.yml.j2" | Variable used to provide custom prometheus configuration file in form of ansible template |
+| `prometheus_rules_files` | [defaults/main.yml#L216](defaults/main.yml#L216) | List of files to put in `rule_files` directive |
 | `prometheus_alert_rules` | [defaults/main.yml#L81](https://github.com/cloudalchemy/ansible-prometheus/blob/73d6df05a775ee5b736ac8f28d5605f2a975d50a/defaults/main.yml#L85) | Full list of alerting rules which will be copied to `{{ prometheus_config_dir }}/rules/ansible_managed.rules`. Alerting rules can be also provided by other files located in `{{ prometheus_config_dir }}/rules/` which have `*.rules` extension |
-| `prometheus_alert_rules_files` | [defaults/main.yml#L78](https://github.com/cloudalchemy/ansible-prometheus/blob/73d6df05a775ee5b736ac8f28d5605f2a975d50a/defaults/main.yml#L78) | List of folders where ansible will look for files containing alerting rules which will be copied to `{{ prometheus_config_dir }}/rules/`. Files must have `*.rules` extension |
+| `prometheus_alert_rules_files` | [defaults/main.yml#L78](https://github.com/cloudalchemy/ansible-prometheus/blob/73d6df05a775ee5b736ac8f28d5605f2a975d50a/defaults/main.yml#L78) | List of folders where ansible will look for files containing alerting rules which will be copied to `{{ prometheus_config_dir }}/rules/`. Files must have `*.rules` extension or you can specify your own with directive prometheus_rules_files_extension |
 | `prometheus_static_targets_files` | [defaults/main.yml#L78](https://github.com/cloudalchemy/ansible-prometheus/blob/73d6df05a775ee5b736ac8f28d5605f2a975d50a/defaults/main.yml#L81) | List of folders where ansible will look for files containing custom static target configuration files which will be copied to `{{ prometheus_config_dir }}/file_sd/`. |
-
+| `prometheus_rules_files_extension` | [defaults/main.yml#L215](defaults/main.yml#L215) | Custom extension of .rules files. See #268 for details|
 
 ### Relation between `prometheus_scrape_configs` and `prometheus_targets`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,7 +78,7 @@ prometheus_scrape_configs:
 prometheus_config_file: 'prometheus.yml.j2'
 
 prometheus_alert_rules_files:
-  - prometheus/rules/*.rules
+  - "prometheus/rules/*.{{ prometheus_rules_files_extension }}"
 
 prometheus_static_targets_files:
   - prometheus/targets/*.yml
@@ -211,3 +211,7 @@ prometheus_alert_rules:
     for: 10m
     labels:
       severity: warning
+
+prometheus_rules_files_extension: "rules"
+prometheus_rules_files:
+  - "{{ prometheus_config_dir }}/rules/ansible_managed.{{ prometheus_rules_files_extension }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,7 +2,7 @@
 - name: alerting rules file
   template:
     src: "alert.rules.j2"
-    dest: "{{ prometheus_config_dir }}/rules/ansible_managed.rules"
+    dest: "{{ prometheus_config_dir }}/rules/ansible_managed.{{ prometheus_rules_files_extension }}"
     owner: root
     group: prometheus
     mode: 0640

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -17,8 +17,12 @@ remote_read:
   {{ prometheus_remote_read | to_nice_yaml(indent=2) | indent(2, False) }}
 {% endif %}
 
+{% if prometheus_rules_files != [] %}
 rule_files:
-  - {{ prometheus_config_dir }}/rules/*.rules
+{% for rule in prometheus_rules_files %}
+  - {{ rule }}
+{% endfor %}
+{% endif %}
 
 {% if prometheus_alertmanager_config | length > 0 %}
 alerting:


### PR DESCRIPTION
See #268 for details. 

Allow overwrite extension of rule files and provide a way to set up more than one line in `rule_files` directive. 