### PR TITLE
Wait for local file systems before starting prometheus

### DIFF
--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -3,6 +3,8 @@
 [Unit]
 Description=Prometheus
 After=network-online.target
+Requires=local-fs.target
+After=local-fs.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
In case prometheus data is stored on mounted volume, wait on it before
starting process.

This change also makes sure that prometheus is stopped to allow safe
unmount volume during shutdown.