### PR TITLE
Role variable for Prometheus download URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 prometheus_version: 2.22.1
+prometheus_download_url: https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz
 prometheus_binary_local_dir: ''
 prometheus_skip_install: false
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
     - name: download prometheus binary to local folder
       become: false
       get_url:
-        url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+        url: "{{ prometheus_download_url }}"
         dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ __prometheus_checksum }}"
       register: _download_archive


### PR DESCRIPTION
We would like to use this role from a server behind a proxy (artifact repository). The PR introduces a new role variable for the Prometheus download URL that will allow us to override the variable default GitHub download URL.