### PR TITLE
docs(travis-ci): replace old travis-ci url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Ansible Role: prometheus
 
-[![Build Status](https://travis-ci.org/cloudalchemy/ansible-prometheus.svg?branch=master)](https://travis-ci.org/cloudalchemy/ansible-prometheus)
+[![Build Status](https://travis-ci.com/cloudalchemy/ansible-prometheus.svg?branch=master)](https://travis-ci.com/cloudalchemy/ansible-prometheus)
 [![License](https://img.shields.io/badge/license-MIT%20License-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Ansible Role](https://img.shields.io/badge/ansible%20role-cloudalchemy.prometheus-blue.svg)](https://galaxy.ansible.com/cloudalchemy/prometheus/)
 [![GitHub tag](https://img.shields.io/github/tag/cloudalchemy/ansible-prometheus.svg)](https://github.com/cloudalchemy/ansible-prometheus/tags)


### PR DESCRIPTION
The PR replaces the old url "travis-ci.org" by the new url "travis-ci.com".