### PR TITLE
Fix version comparison issue when using binary_local_dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-prometheus_version: 2.24.1
+prometheus_version: "2.24.1"
 prometheus_binary_local_dir: ''
 prometheus_skip_install: false
 


### PR DESCRIPTION
As I was using prometheus_binary_local_dir to copy version 2.24.1, I didn't overwrite the default prometheus_version variable. For some bizarre reason, the "2.24.1" was being interpreted as an int in the version comparison in templates/prometheus.service.j2 and triggering a '<' not supported between instances of 'str' and 'int'.