### PR TITLE
Add option for ReadOnlyPaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `prometheus_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `prometheus` AND `promtool` binaries are stored on host on which ansible is ran. This overrides `prometheus_version` parameter |
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
 | `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
+| `prometheus_read_only_dirs`| [] | Additional paths that Prometheus is allowed to read (useful for SSL certs outside of the config directory) |
 | `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |
+| `prometheus_web_config` | {} | A Prometheus [web config yaml](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md) for configuring TLS and auth. |
 | `prometheus_web_external_url` | "" | External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus` |
 | `prometheus_storage_retention` | "30d" | Data retention period |
 | `prometheus_storage_retention_size` | "0" | Data retention period by size |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ prometheus_skip_install: false
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus
+prometheus_read_only_dirs: []
 
 prometheus_web_listen_address: "0.0.0.0:9090"
 prometheus_web_external_url: ''

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -10,6 +10,8 @@
     prometheus_db_dir: /opt/prom/lib
     prometheus_web_listen_address: "127.0.0.1:9090"
     prometheus_web_external_url: "http://127.0.0.1:9090/prometheus"
+    prometheus_read_only_dirs:
+      - /etc
     prometheus_storage_retention: "60d"
     prometheus_storage_retention_size: "1GB"
     prometheus_config_flags_extra:

--- a/molecule/alternative/tests/test_alternative.py
+++ b/molecule/alternative/tests/test_alternative.py
@@ -23,7 +23,6 @@ def test_directories(host, dirs):
     "/opt/prom/etc/rules/ansible_managed.rules",
     "/opt/prom/etc/file_sd/node.yml",
     "/opt/prom/etc/file_sd/docker.yml",
-    "/etc/systemd/system/prometheus.service",
     "/usr/local/bin/prometheus",
     "/usr/local/bin/promtool"
 ])
@@ -31,6 +30,16 @@ def test_files(host, files):
     f = host.file(files)
     assert f.exists
     assert f.is_file
+
+
+@pytest.mark.parametrize('file, content', [
+    ("/etc/systemd/system/prometheus.service", "ReadOnly.*=/etc"),
+])
+def test_file_contents(host, file, content):
+    f = host.file(file)
+    assert f.exists
+    assert f.is_file
+    assert f.contains(content)
 
 
 def test_service(host):

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -44,8 +44,14 @@ RestrictSUIDSGID=true
 
 {% if prometheus_systemd_version | int >= 231 %}
 ReadWritePaths={{ prometheus_db_dir }}
+{% for path in prometheus_read_only_dirs %}
+ReadOnlyPaths={{ path }}
+{% endfor %}
 {% else %}
 ReadWriteDirectories={{ prometheus_db_dir }}
+{% for path in prometheus_read_only_dirs %}
+ReadOnlyDirectories={{ path }}
+{% endfor %}
 {% endif %}
 
 {% if prometheus_systemd_version | int >= 232 %}


### PR DESCRIPTION
Add an option to allow adding ReadOnlyPaths to systemd protection. This
is useful for allowing access to TLS certs outside of the config
directory.
* Update README with `prometheus_web_config`.

[feature]

Signed-off-by: Ben Kochie <superq@gmail.com>