### PR TITLE
Avoid re-use of images between phases.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
       - run: molecule test -s default --destroy always
       - run: |
          if [[ -d 'molecule/alternative' ]]; then
-           molecule test -s alternative --destroy never
+           molecule test -s alternative --destroy always
          else
            echo 'No alternative test'
          fi
       - run: |
          if [[ -z "${CIRCLE_PULL_REQUEST}" ]] && [[ -d 'molecule/latest' ]]; then
-           molecule test -s latest --destroy never
+           molecule test -s latest --destroy always
          else
            echo 'Not running latest on PR'
          fi


### PR DESCRIPTION
Always destroy test docker images between test phases. Otherwise they
pollute each phase.

[minor] release

Signed-off-by: Ben Kochie <superq@gmail.com>