### PR TITLE
Fix CircleCI version bumping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,16 +53,11 @@ jobs:
       - run: pip install git-semver
       - run: git config --global user.email "${GIT_MAIL}"
       - run: git config --global user.name "${GIT_USER}"
+      - run: ./bump_version >> $BASH_ENV
       - run: |
-          GIT_TAG=none
-          echo "Last commit message: ${GIT_COMMIT_DESC}"
-          case "${GIT_COMMIT_DESC}" in
-            *"[patch]"*|*"[fix]"*|*"[bugfix]"* )   GIT_TAG=$(git semver --next-patch) ;;
-            *"[minor]"*|*"[feat]"*|*"[feature]"* ) GIT_TAG=$(git semver --next-minor) ;;
-            *"[major]"*|*"[breaking change]"* )    GIT_TAG=$(git semver --next-major) ;;
-            *) echo "Keyword not detected. Doing nothing" && circleci-agent step halt ;;
-          esac
-          echo "GIT_TAG=${GIT_TAG}" >> $BASH_ENV
+          if [[ "${NEW_TAG}" == 'none' ]]; then
+            echo "Keyword not detected. Doing nothing" && circleci-agent step halt
+          fi
       - run: |
           docker run -it --rm \
            -v "${CIRCLE_WORKING_DIRECTORY}:/role" \
@@ -73,7 +68,7 @@ jobs:
            --token "${GH_TOKEN}" \
            --release-url "https://galaxy.ansible.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME#ansible-}" \
            --unreleased-label "**Next release**" --no-compare-link \
-           --future-release "${GIT_TAG}"
+           --future-release "${NEW_TAG}"
       - run: git add CHANGELOG.md
       - run: git commit -m "[ci skip] Automatic changelog update"
       - run: git push "https://${GH_TOKEN}:@${GIT_URL}" || circleci-agent step halt

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Description: Generate the next release version
+
+set -uo pipefail
+
+latest_tag="$(git semver)"
+if [[ -z "${latest_tag}" ]]; then
+  echo "ERROR: Couldn't get latest tag from git semver, try 'pip install git-semver'" 2>&1
+  exit 1
+fi
+
+# Use HEAD if CIRCLE_SHA1 is not set.
+now="${CIRCLE_SHA1:-HEAD}"
+
+new_tag='none'
+git_log="$(git log --format=%B "${latest_tag}..${now}")"
+
+case "${git_log}" in
+  *"[major]"*|*"[breaking change]"* )    new_tag=$(git semver --next-major) ;;
+  *"[minor]"*|*"[feat]"*|*"[feature]"* ) new_tag=$(git semver --next-minor) ;;
+  *"[patch]"*|*"[fix]"*|*"[bugfix]"* )   new_tag=$(git semver --next-patch) ;;
+esac
+
+echo "NEW_TAG=${new_tag}"


### PR DESCRIPTION
Better handle multiple commits and merge commits by looking backwards to
the last tagged version, rather than only the last commit.

Signed-off-by: Ben Kochie <superq@gmail.com>