### PR TITLE
Fix the circleci error in release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           fi
       - run: |
           docker run -it --rm \
-           -v "${CIRCLE_WORKING_DIRECTORY}:/role" \
+           -v ${CIRCLE_WORKING_DIRECTORY}:/role \
            -w "/role" \
            ferrarimarco/github-changelog-generator:1.15.2 \
            --user "${CIRCLE_PROJECT_USERNAME}" \


### PR DESCRIPTION
 docker: Error response from daemon: create ~/project: "~/project"
 includes invalid characters for a local volume name, only
 "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host
 directory, use absolute path.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>