### PR TITLE
Remove docker use from release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,37 +46,43 @@ jobs:
     environment:
       GIT_MAIL: cloudalchemybot@gmail.com
       GIT_USER: cloudalchemybot
-      GIT_COMMIT_DESC: git log --format=%B -n 1 ${CIRCLE_SHA1}
+      GIT_CHGLOG_URL: https://github.com/git-chglog/git-chglog/releases/download/v0.14.0/git-chglog_0.14.0_linux_amd64.tar.gz
+      GIT_CHGLOG_SUM: ed65b1c1dad41ca0372ebc86cf4102cdbb3397259461f1c3730c4c61075a618a
     steps:
       - checkout
-      - setup_remote_docker
       - run: pip install git-semver
       - run: git config --global user.email "${GIT_MAIL}"
       - run: git config --global user.name "${GIT_USER}"
       - run: ./bump_version.sh >> $BASH_ENV
-      - run: |
-          if [[ "${NEW_TAG}" == 'none' ]]; then
-            echo "Keyword not detected. Doing nothing" && circleci-agent step halt
-          else
-            echo "Bumping to ${NEW_TAG}"
-          fi
-      - run: |
-          echo "Running in ${PWD}" && docker run --rm \
-           -v "${PWD}:/workdir" \
-           quay.io/git-chglog/git-chglog:latest \
-             --output CHANGELOG.md \
-             --next-tag "${NEW_TAG}"
+      - run:
+          name: Checking for new tag
+          command: |
+            if [[ "${NEW_TAG}" == 'none' ]]; then
+              echo "Keyword not detected. Doing nothing" && circleci-agent step halt
+            else
+              echo "Bumping to ${NEW_TAG}"
+            fi
+      - run:
+          name: Downloading git-chglog
+          command: |
+            curl -sL --fail "${GIT_CHGLOG_URL}" -o 'git-chglog.tar.gz' && \
+            sha256sum -c <(echo "${GIT_CHGLOG_SUM} git-chglog.tar.gz") && \
+            tar -zvxf git-chglog.tar.gz git-chglog && \
+            chhmod 755 git-chglog
+      - run: ./git-chglog --output CHANGELOG.md --next-tag "${NEW_TAG}"
       - run: git add CHANGELOG.md
       - run: git commit -m "[ci skip] Automatic changelog update"
       - run: git push "https://${GH_TOKEN}:@${GIT_URL}" || circleci-agent step halt
-      - run: |
-          ghr \
-            -t ${GH_TOKEN} \
-            -u ${CIRCLE_PROJECT_USERNAME} \
-            -r ${CIRCLE_PROJECT_REPONAME} \
-            -n ${NEW_TAG} \
-            -b "$(sed -n -e '/## \[0.22.0\]/,/## \[/ p' CHANGELOG.md | sed -e '$ d')" \
-            ${NEW_TAG}
+      - run:
+          name: Publishing release
+          command: |
+            ghr \
+              -t ${GH_TOKEN} \
+              -u ${CIRCLE_PROJECT_USERNAME} \
+              -r ${CIRCLE_PROJECT_REPONAME} \
+              -n ${NEW_TAG} \
+              -b "$(sed -n -e '/## \[0.22.0\]/,/## \[/ p' CHANGELOG.md | sed -e '$ d')" \
+              ${NEW_TAG}
   galaxy:
     executor: python
     steps:


### PR DESCRIPTION
Remove docker use since volume mounts don't work.
* Download git-chglog binary.
* Make CI job steps pretty with named commands.
* Remove DinD setup.

Signed-off-by: Ben Kochie <superq@gmail.com>