### PR TITLE
Custom recording rules

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,9 @@ prometheus_config_file: 'prometheus.yml.j2'
 prometheus_alert_rules_files:
   - prometheus/rules/*.rules
 
+prometheus_recording_rules_files:
+  - prometheus/recording_rules/*.rules
+
 prometheus_static_targets_files:
   - prometheus/targets/*.yml
   - prometheus/targets/*.json
@@ -217,3 +220,5 @@ prometheus_alert_rules:
     for: 10m
     labels:
       severity: warning
+
+  prometheus_alert_rules: []

--- a/molecule/alternative/tests/test_alternative.py
+++ b/molecule/alternative/tests/test_alternative.py
@@ -9,6 +9,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 @pytest.mark.parametrize("dirs", [
     "/opt/prom/etc",
     "/opt/prom/etc/rules",
+    "/opt/prom/etc/recording_rules",
     "/opt/prom/etc/file_sd",
     "/opt/prom/lib"
 ])
@@ -21,6 +22,7 @@ def test_directories(host, dirs):
 @pytest.mark.parametrize("files", [
     "/opt/prom/etc/prometheus.yml",
     "/opt/prom/etc/rules/ansible_managed.rules",
+    "/opt/prom/etc/recording_rules/ansible_managed.rules",
     "/opt/prom/etc/file_sd/node.yml",
     "/opt/prom/etc/file_sd/docker.yml",
     "/usr/local/bin/prometheus",

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,6 +18,7 @@ def AnsibleDefaults():
     "/etc/prometheus/console_libraries",
     "/etc/prometheus/consoles",
     "/etc/prometheus/rules",
+    "/etc/prometheus/recording_rules",
     "/etc/prometheus/file_sd",
     "/var/lib/prometheus"
 ])
@@ -43,7 +44,8 @@ def test_files(host, files):
 
 
 @pytest.mark.parametrize("files", [
-    "/etc/prometheus/rules/ansible_managed.rules"
+    "/etc/prometheus/rules/ansible_managed.rules",
+    "/etc/prometheus/recording_rules/ansible_managed.rules"
 ])
 def test_absent(host, files):
     f = host.file(files)

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -24,6 +24,31 @@
   notify:
     - reload prometheus
 
+- name: recording rules file
+  template:
+    src: "recording.rules.j2"
+    dest: "{{ prometheus_config_dir }}/recording_rules/ansible_managed.rules"
+    owner: root
+    group: prometheus
+    mode: 0640
+    validate: "{{ _prometheus_binary_install_dir }}/promtool check rules %s"
+  when:
+    - prometheus_recording_rules != []
+  notify:
+    - reload prometheus
+
+- name: copy custom recording rule files
+  copy:
+    src: "{{ item }}"
+    dest: "{{ prometheus_config_dir }}/recording_rules/"
+    owner: root
+    group: prometheus
+    mode: 0640
+    validate: "{{ _prometheus_binary_install_dir }}/promtool check rules %s"
+  with_fileglob: "{{ prometheus_recording_rules_files }}"
+  notify:
+    - reload prometheus
+
 - name: configure prometheus
   template:
     src: "{{ prometheus_config_file }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,6 +32,7 @@
   with_items:
     - "{{ prometheus_config_dir }}"
     - "{{ prometheus_config_dir }}/rules"
+    - "{{ prometheus_config_dir }}/recording_rules"
     - "{{ prometheus_config_dir }}/file_sd"
 
 - block:

--- a/templates/recording.rules.j2
+++ b/templates/recording.rules.j2
@@ -1,0 +1,6 @@
+{{ ansible_managed | comment }}
+
+groups:
+- name: ansible managed recording rules
+  rules:
+  {{ prometheus_recording_rules | to_nice_yaml(indent=2) | indent(2,False) }}


### PR DESCRIPTION
This PR add support for [recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/). The rules are in the same format and validated in the same way as the alerting rules, so this is pretty much just the alerting rule tasks but renamed. I left the default rules blank as there aren't really generic recording rules that would serve a purpose by default (that I am aware of).

I tried to run local tests, but it seems tox may not be used anymore?