### PR TITLE
Changes to run multiple prometheus instances on one server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
 | `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
 | `prometheus_read_only_dirs`| [] | Additional paths that Prometheus is allowed to read (useful for SSL certs outside of the config directory) |
+| `prometheus_system_user` | prometheus | Name of the prometheus user |
+| `prometheus_system_group` | prometheus | Name of the prometheus group |
+| `prometheus_systemd_service_name` | prometheus | Name of the prometheus systemd service |
 | `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |
 | `prometheus_web_config` | {} | A Prometheus [web config yaml](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md) for configuring TLS and auth. |
 | `prometheus_web_external_url` | "" | External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ prometheus_read_only_dirs: []
 prometheus_system_user: prometheus
 prometheus_system_group: prometheus
 
-prometheus_systemd_servicename: prometheus
+prometheus_systemd_service_name: prometheus
 
 prometheus_web_listen_address: "0.0.0.0:9090"
 prometheus_web_external_url: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus
 prometheus_read_only_dirs: []
 
+prometheus_system_user: prometheus
+prometheus_system_group: prometheus
+
 prometheus_web_listen_address: "0.0.0.0:9090"
 prometheus_web_external_url: ''
 # See https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@ prometheus_read_only_dirs: []
 prometheus_system_user: prometheus
 prometheus_system_group: prometheus
 
+prometheus_systemd_servicename: prometheus
+
 prometheus_web_listen_address: "0.0.0.0:9090"
 prometheus_web_external_url: ''
 # See https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,11 +3,11 @@
   become: true
   systemd:
     daemon_reload: true
-    name: {{ prometheus_systemd_service_name }}
+    name: "{{ prometheus_systemd_service_name }}"
     state: restarted
 
 - name: reload prometheus
   become: true
   systemd:
-    name: {{ prometheus_systemd_service_name }}
+    name: "{{ prometheus_systemd_service_name }}"
     state: reloaded

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,11 +3,11 @@
   become: true
   systemd:
     daemon_reload: true
-    name: prometheus
+    name: {{ prometheus_systemd_service_name }}
     state: restarted
 
 - name: reload prometheus
   become: true
   systemd:
-    name: prometheus
+    name: {{ prometheus_systemd_service_name }}
     state: reloaded

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,7 +4,7 @@
     src: "alert.rules.j2"
     dest: "{{ prometheus_config_dir }}/rules/ansible_managed.rules"
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
     validate: "{{ _prometheus_binary_install_dir }}/promtool check rules %s"
   when:
@@ -17,7 +17,7 @@
     src: "{{ item }}"
     dest: "{{ prometheus_config_dir }}/rules/"
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
     validate: "{{ _prometheus_binary_install_dir }}/promtool check rules %s"
   with_fileglob: "{{ prometheus_alert_rules_files }}"
@@ -30,7 +30,7 @@
     dest: "{{ prometheus_config_dir }}/prometheus.yml"
     force: true
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
     validate: "{{ _prometheus_binary_install_dir }}/promtool check config %s"
   notify:
@@ -42,7 +42,7 @@
     dest: "{{ prometheus_config_dir }}/web.yml"
     force: true
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
 
 - name: configure prometheus static targets
@@ -53,7 +53,7 @@
     dest: "{{ prometheus_config_dir }}/file_sd/{{ item.key }}.yml"
     force: true
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
   with_dict: "{{ prometheus_targets }}"
   when: prometheus_targets != {}
@@ -64,6 +64,6 @@
     dest: "{{ prometheus_config_dir }}/file_sd/"
     force: true
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0640
   with_fileglob: "{{ prometheus_static_targets_files }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,16 +1,16 @@
 ---
 - name: create prometheus system group
   group:
-    name: prometheus
+    name: "{{ prometheus_system_group }}"
     system: true
     state: present
 
 - name: create prometheus system user
   user:
-    name: prometheus
+    name: "{{ prometheus_system_group }}"
     system: true
     shell: "/usr/sbin/nologin"
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     createhome: false
     home: "{{ prometheus_db_dir }}"
 
@@ -18,8 +18,8 @@
   file:
     path: "{{ prometheus_db_dir }}"
     state: directory
-    owner: prometheus
-    group: prometheus
+    owner: "{{ prometheus_system_user }}"
+    group: "{{ prometheus_system_group }}"
     mode: 0755
 
 - name: create prometheus configuration directories
@@ -27,7 +27,7 @@
     path: "{{ item }}"
     state: directory
     owner: root
-    group: prometheus
+    group: "{{ prometheus_system_group }}"
     mode: 0770
   with_items:
     - "{{ prometheus_config_dir }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -106,7 +106,7 @@
 - name: create systemd service unit
   template:
     src: prometheus.service.j2
-    dest: /etc/systemd/system/prometheus.service
+    dest: /etc/systemd/system/{{ prometheus_systemd_service_name }}.service
     owner: root
     group: root
     mode: 0644

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,13 +1,13 @@
 ---
-- name: create prometheus system group
+- name: create {{ prometheus_system_group }} system group
   group:
     name: "{{ prometheus_system_group }}"
     system: true
     state: present
 
-- name: create prometheus system user
+- name: create {{ prometheus_system_user }} system user
   user:
-    name: "{{ prometheus_system_group }}"
+    name: "{{ prometheus_system_user }}"
     system: true
     shell: "/usr/sbin/nologin"
     group: "{{ prometheus_system_group }}"

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 
 [Unit]
-Description=Prometheus
+Description={{ prometheus_systemd_service_name }}
 After=network-online.target
 Requires=local-fs.target
 After=local-fs.target

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -9,8 +9,8 @@ After=local-fs.target
 [Service]
 Type=simple
 Environment="GOMAXPROCS={{ ansible_processor_vcpus|default(ansible_processor_count) }}"
-User=prometheus
-Group=prometheus
+User={{ prometheus_system_user }}
+Group={{ prometheus_system_group }}
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ _prometheus_binary_install_dir }}/prometheus \
   --storage.tsdb.path={{ prometheus_db_dir }} \


### PR DESCRIPTION
## The problem

If you want a public dashboard in grafana it exposes the datasources to the public user. therefore i need to split up my datasources in public and private. For that i need multiple prometheus instances on one server

## My changes

I added 3 variables. 2 to change the system users name and group and one to change the name of the systemd service