### PR TITLE
fix: add family-version.yml support to variable loader task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   with_first_found:
     - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_distribution | lower }}.yml"
+    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:
     - prometheus_configure


### PR DESCRIPTION
I was trying to run this from a [Rocky Linux](https://rockylinux.org) installation when I noticed that it's using `redhat.yml` to load the packages for SELinux, not `redhat-8.yml` -- this should fix that problem and allow _any_ RHEL8 derivative distro to use the correct package names, like CentOS does.