### PR TITLE
Add Rocky Linux support

### DIFF
--- a/vars/rocky-8.yml
+++ b/vars/rocky-8.yml
@@ -1,0 +1,4 @@
+---
+prometheus_selinux_packages:
+  - python3-libselinux
+  - python3-policycoreutils


### PR DESCRIPTION
This is a workaround because Rocky Linux is not identified as RedHat until Ansible 2.11.
https://forums.rockylinux.org/t/ansible-os-family-question/3320