### PR TITLE
Remove unnecessary dependency on jmespath

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ When upgrading from <= 2.4.0 version of this role to >= 2.4.1 please turn off yo
 ## Requirements
 
 - Ansible >= 2.7 (It might work on previous versions, but we cannot guarantee it)
-- jmespath on deployer machine. If you are using Ansible from a Python virtualenv, install *jmespath* to the same virtualenv via pip.
 - gnu-tar on Mac deployer host (`brew install gnu-tar`)
 
 ## Role Variables

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -52,7 +52,7 @@
 
 - name: Get all file_sd files from scrape_configs
   set_fact:
-    file_sd_files: "{{ prometheus_scrape_configs | json_query('[*][].file_sd_configs[*][].files[]') }}"
+    file_sd_files: "{{ prometheus_scrape_configs | selectattr('file_sd_configs', 'defined') | map(attribute='file_sd_configs') | flatten | map(attribute='files') | flatten }}"
 
 - name: Fail when file_sd targets are not defined in scrape_configs
   fail:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,5 @@ molecule-docker
 docker
 ansible-lint>=3.4.0
 testinfra>=1.7.0
-jmespath
 selinux
 passlib


### PR DESCRIPTION
This is fairly straightforward manipulation to do with standard Jinja features, there's no need to use a non-default library.