### PR TITLE
Add OracleLinux support

### DIFF
--- a/vars/oraclelinux.yml
+++ b/vars/oraclelinux.yml
@@ -1,0 +1,4 @@
+---
+prometheus_selinux_packages:
+  - python3-libselinux
+  - python3-policycoreutils


### PR DESCRIPTION
Oracle Linux is identified as `ansible_distribution = OracleLinux`, and needs the same package installation as CentOS 8 or RHEL.