### PR TITLE
Retain order in yaml dictionaries

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -38,7 +38,7 @@
 
 - name: configure Prometheus web
   copy:
-    content: "{{ prometheus_web_config | to_nice_yaml(indent=2) }}"
+    content: "{{ prometheus_web_config | to_nice_yaml(indent=2,sort_keys=False) }}"
     dest: "{{ prometheus_config_dir }}/web.yml"
     force: true
     owner: root
@@ -49,7 +49,7 @@
   copy:
     content: |
       #jinja2: lstrip_blocks: True
-      {{ item.value | to_nice_yaml(indent=2) }}
+      {{ item.value | to_nice_yaml(indent=2,sort_keys=False) }}
     dest: "{{ prometheus_config_dir }}/file_sd/{{ item.key }}.yml"
     force: true
     owner: root

--- a/templates/alert.rules.j2
+++ b/templates/alert.rules.j2
@@ -3,4 +3,4 @@
 groups:
 - name: ansible managed alert rules
   rules:
-  {{ prometheus_alert_rules | to_nice_yaml(indent=2) | indent(2,False) }}
+  {{ prometheus_alert_rules | to_nice_yaml(indent=2,sort_keys=False) | indent(2,False) }}

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -3,18 +3,18 @@
 # http://prometheus.io/docs/operating/configuration/
 
 global:
-  {{ prometheus_global | to_nice_yaml(indent=2) | indent(2, False) }}
+  {{ prometheus_global | to_nice_yaml(indent=2,sort_keys=False) | indent(2, False) }}
   external_labels:
-    {{ prometheus_external_labels | to_nice_yaml(indent=2) | indent(4, False) }}
+    {{ prometheus_external_labels | to_nice_yaml(indent=2,sort_keys=False) | indent(4, False) }}
 
 {% if prometheus_remote_write != [] %}
 remote_write:
-  {{ prometheus_remote_write | to_nice_yaml(indent=2) | indent(2, False) }}
+  {{ prometheus_remote_write | to_nice_yaml(indent=2,sort_keys=False) | indent(2, False) }}
 {% endif %}
 
 {% if prometheus_remote_read != [] %}
 remote_read:
-  {{ prometheus_remote_read | to_nice_yaml(indent=2) | indent(2, False) }}
+  {{ prometheus_remote_read | to_nice_yaml(indent=2,sort_keys=False) | indent(2, False) }}
 {% endif %}
 
 rule_files:
@@ -23,12 +23,12 @@ rule_files:
 {% if prometheus_alertmanager_config | length > 0 %}
 alerting:
   alertmanagers:
-  {{ prometheus_alertmanager_config | to_nice_yaml(indent=2) | indent(2,False) }}
+  {{ prometheus_alertmanager_config | to_nice_yaml(indent=2,sort_keys=False) | indent(2,False) }}
   {% if prometheus_alert_relabel_configs | length > 0 %}
   alert_relabel_configs:
-  {{ prometheus_alert_relabel_configs | to_nice_yaml(indent=2) | indent(2,False) }}
+  {{ prometheus_alert_relabel_configs | to_nice_yaml(indent=2,sort_keys=False) | indent(2,False) }}
   {% endif %}
 {% endif %}
 
 scrape_configs:
-  {{ prometheus_scrape_configs | to_nice_yaml(indent=2) | indent(2,False) }}
+  {{ prometheus_scrape_configs | to_nice_yaml(indent=2,sort_keys=False) | indent(2,False) }}


### PR DESCRIPTION
In group_vars, the scrape_configs are nicely formatted with job_name at the top.  That is clear and readable.

Then, you run ansible and it generates the prometheus.yml file.  The resulting scrape configs are jumbled.  They lose the previous ordering.   

The solution is adding `sort_keys=False` to the to_nice_yaml filter.

References:
https://github.com/yaml/pyyaml/issues/110  
https://github.com/ansible/ansible/issues/76638