### PR TITLE
Allow alert rule groups

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,6 +91,8 @@ prometheus_static_targets_files:
   - prometheus/targets/*.json
 
 prometheus_alert_rules:
+- name: ansible managed alert rules
+  rules:
   - alert: Watchdog
     expr: vector(1)
     for: 10m

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,131 +91,131 @@ prometheus_static_targets_files:
   - prometheus/targets/*.json
 
 prometheus_alert_rules:
-- name: ansible managed alert rules
-  rules:
-  - alert: Watchdog
-    expr: vector(1)
-    for: 10m
-    labels:
-      severity: warning
-    annotations:
-      description: "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty."
-      summary: 'Ensure entire alerting pipeline is functional'
-  - alert: InstanceDown
-    expr: 'up == 0'
-    for: 5m
-    labels:
-      severity: critical
-    annotations:
-      description: '{% raw %}{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.{% endraw %}'
-      summary: '{% raw %}Instance {{ $labels.instance }} down{% endraw %}'
-  - alert: RebootRequired
-    expr: 'node_reboot_required > 0'
-    labels:
-      severity: warning
-    annotations:
-      description: '{% raw %}{{ $labels.instance }} requires a reboot.{% endraw %}'
-      summary: '{% raw %}Instance {{ $labels.instance }} - reboot required{% endraw %}'
-  - alert: NodeFilesystemSpaceFillingUp
-    annotations:
-      description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left and is filling up.{% endraw %}'
-      summary: 'Filesystem is predicted to run out of space within the next 24 hours.'
-    expr: "(\n  node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"node\",fstype!=\"\"} * 100 < 40\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"}[6h], 24*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
-    for: 1h
-    labels:
-      severity: warning
-  - alert: NodeFilesystemSpaceFillingUp
-    annotations:
-      description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left and is filling up fast.{% endraw %}'
-      summary: 'Filesystem is predicted to run out of space within the next 4 hours.'
-    expr: "(\n  node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"node\",fstype!=\"\"} * 100 < 20\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"}[6h], 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
-    for: 1h
-    labels:
-      severity: critical
-  - alert: NodeFilesystemAlmostOutOfSpace
-    annotations:
-      description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left.{% endraw %}'
-      summary: 'Filesystem has less than 5% space left.'
-    expr: "(\n  node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"node\",fstype!=\"\"} * 100 < 5\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
-    for: 1h
-    labels:
-      severity: warning
-  - alert: NodeFilesystemAlmostOutOfSpace
-    annotations:
-      description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left.{% endraw %}'
-      summary: 'Filesystem has less than 3% space left.'
-    expr: "(\n  node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"node\",fstype!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
-    for: 1h
-    labels:
-      severity: critical
-  - alert: NodeFilesystemFilesFillingUp
-    annotations:
-      description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up.{% endraw %}'
-      summary: 'Filesystem is predicted to run out of inodes within the next 24 hours.'
-    expr: "(\n  node_filesystem_files_free{job=\"node\",fstype!=\"\"} / node_filesystem_files{job=\"node\",fstype!=\"\"} * 100 < 40\nand\n  predict_linear(node_filesystem_files_free{job=\"node\",fstype!=\"\"}[6h], 24*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
-    for: 1h
-    labels:
-      severity: warning
-  - alert: NodeFilesystemFilesFillingUp
-    annotations:
-      description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up fast.{% endraw %}'
-      summary: 'Filesystem is predicted to run out of inodes within the next 4 hours.'
-    expr: "(\n  node_filesystem_files_free{job=\"node\",fstype!=\"\"} / node_filesystem_files{job=\"node\",fstype!=\"\"} * 100 < 20\nand\n  predict_linear(node_filesystem_files_free{job=\"node\",fstype!=\"\"}[6h], 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
-    for: 1h
-    labels:
-      severity: critical
-  - alert: NodeFilesystemAlmostOutOfFiles
-    annotations:
-      description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.{% endraw %}'
-      summary: 'Filesystem has less than 5% inodes left.'
-    expr: "(\n  node_filesystem_files_free{job=\"node\",fstype!=\"\"} / node_filesystem_files{job=\"node\",fstype!=\"\"} * 100 < 5\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
-    for: 1h
-    labels:
-      severity: warning
-  - alert: NodeFilesystemAlmostOutOfFiles
-    annotations:
-      description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.{% endraw %}'
-      summary: 'Filesystem has less than 3% inodes left.'
-    expr: "(\n  node_filesystem_files_free{job=\"node\",fstype!=\"\"} / node_filesystem_files{job=\"node\",fstype!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
-    for: 1h
-    labels:
-      severity: critical
-  - alert: NodeNetworkReceiveErrs
-    annotations:
-      description: '{% raw %}{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last two minutes.{% endraw %}'
-      summary: 'Network interface is reporting many receive errors.'
-    expr: "increase(node_network_receive_errs_total[2m]) > 10\n"
-    for: 1h
-    labels:
-      severity: warning
-  - alert: NodeNetworkTransmitErrs
-    annotations:
-      description: '{% raw %}{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} transmit errors in the last two minutes.{% endraw %}'
-      summary: 'Network interface is reporting many transmit errors.'
-    expr: "increase(node_network_transmit_errs_total[2m]) > 10\n"
-    for: 1h
-    labels:
-      severity: warning
-  - alert: NodeHighNumberConntrackEntriesUsed
-    annotations:
-      description: '{% raw %}{{ $value | humanizePercentage }} of conntrack entries are used{% endraw %}'
-      summary: 'Number of conntrack are getting close to the limit'
-    expr: "(node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75\n"
-    labels:
-      severity: warning
-  - alert: NodeClockSkewDetected
-    annotations:
-      message: '{% raw %}Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.{% endraw %}'
-      summary: 'Clock skew detected.'
-    expr: "(\n  node_timex_offset_seconds > 0.05\nand\n  deriv(node_timex_offset_seconds[5m]) >= 0\n)\nor\n(\n  node_timex_offset_seconds < -0.05\nand\n  deriv(node_timex_offset_seconds[5m]) <= 0\n)\n"
-    for: 10m
-    labels:
-      severity: warning
-  - alert: NodeClockNotSynchronising
-    annotations:
-      message: '{% raw %}Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.{% endraw %}'
-      summary: 'Clock not synchronising.'
-    expr: "min_over_time(node_timex_sync_status[5m]) == 0\n"
-    for: 10m
-    labels:
-      severity: warning
+  - name: ansible managed alert rules
+    rules:
+      - alert: Watchdog
+        expr: vector(1)
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          description: "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty."
+          summary: 'Ensure entire alerting pipeline is functional'
+      - alert: InstanceDown
+        expr: 'up == 0'
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: '{% raw %}{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.{% endraw %}'
+          summary: '{% raw %}Instance {{ $labels.instance }} down{% endraw %}'
+      - alert: RebootRequired
+        expr: 'node_reboot_required > 0'
+        labels:
+          severity: warning
+        annotations:
+          description: '{% raw %}{{ $labels.instance }} requires a reboot.{% endraw %}'
+          summary: '{% raw %}Instance {{ $labels.instance }} - reboot required{% endraw %}'
+      - alert: NodeFilesystemSpaceFillingUp
+        annotations:
+          description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left and is filling up.{% endraw %}'
+          summary: 'Filesystem is predicted to run out of space within the next 24 hours.'
+        expr: "(\n  node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"node\",fstype!=\"\"} * 100 < 40\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"}[6h], 24*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeFilesystemSpaceFillingUp
+        annotations:
+          description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left and is filling up fast.{% endraw %}'
+          summary: 'Filesystem is predicted to run out of space within the next 4 hours.'
+        expr: "(\n  node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"node\",fstype!=\"\"} * 100 < 20\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"}[6h], 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
+        for: 1h
+        labels:
+          severity: critical
+      - alert: NodeFilesystemAlmostOutOfSpace
+        annotations:
+          description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left.{% endraw %}'
+          summary: 'Filesystem has less than 5% space left.'
+        expr: "(\n  node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"node\",fstype!=\"\"} * 100 < 5\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeFilesystemAlmostOutOfSpace
+        annotations:
+          description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left.{% endraw %}'
+          summary: 'Filesystem has less than 3% space left.'
+        expr: "(\n  node_filesystem_avail_bytes{job=\"node\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"node\",fstype!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
+        for: 1h
+        labels:
+          severity: critical
+      - alert: NodeFilesystemFilesFillingUp
+        annotations:
+          description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up.{% endraw %}'
+          summary: 'Filesystem is predicted to run out of inodes within the next 24 hours.'
+        expr: "(\n  node_filesystem_files_free{job=\"node\",fstype!=\"\"} / node_filesystem_files{job=\"node\",fstype!=\"\"} * 100 < 40\nand\n  predict_linear(node_filesystem_files_free{job=\"node\",fstype!=\"\"}[6h], 24*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeFilesystemFilesFillingUp
+        annotations:
+          description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up fast.{% endraw %}'
+          summary: 'Filesystem is predicted to run out of inodes within the next 4 hours.'
+        expr: "(\n  node_filesystem_files_free{job=\"node\",fstype!=\"\"} / node_filesystem_files{job=\"node\",fstype!=\"\"} * 100 < 20\nand\n  predict_linear(node_filesystem_files_free{job=\"node\",fstype!=\"\"}[6h], 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
+        for: 1h
+        labels:
+          severity: critical
+      - alert: NodeFilesystemAlmostOutOfFiles
+        annotations:
+          description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.{% endraw %}'
+          summary: 'Filesystem has less than 5% inodes left.'
+        expr: "(\n  node_filesystem_files_free{job=\"node\",fstype!=\"\"} / node_filesystem_files{job=\"node\",fstype!=\"\"} * 100 < 5\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeFilesystemAlmostOutOfFiles
+        annotations:
+          description: '{% raw %}Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.{% endraw %}'
+          summary: 'Filesystem has less than 3% inodes left.'
+        expr: "(\n  node_filesystem_files_free{job=\"node\",fstype!=\"\"} / node_filesystem_files{job=\"node\",fstype!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"node\",fstype!=\"\"} == 0\n)\n"
+        for: 1h
+        labels:
+          severity: critical
+      - alert: NodeNetworkReceiveErrs
+        annotations:
+          description: '{% raw %}{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last two minutes.{% endraw %}'
+          summary: 'Network interface is reporting many receive errors.'
+        expr: "increase(node_network_receive_errs_total[2m]) > 10\n"
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeNetworkTransmitErrs
+        annotations:
+          description: '{% raw %}{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} transmit errors in the last two minutes.{% endraw %}'
+          summary: 'Network interface is reporting many transmit errors.'
+        expr: "increase(node_network_transmit_errs_total[2m]) > 10\n"
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeHighNumberConntrackEntriesUsed
+        annotations:
+          description: '{% raw %}{{ $value | humanizePercentage }} of conntrack entries are used{% endraw %}'
+          summary: 'Number of conntrack are getting close to the limit'
+        expr: "(node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75\n"
+        labels:
+          severity: warning
+      - alert: NodeClockSkewDetected
+        annotations:
+          message: '{% raw %}Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.{% endraw %}'
+          summary: 'Clock skew detected.'
+        expr: "(\n  node_timex_offset_seconds > 0.05\nand\n  deriv(node_timex_offset_seconds[5m]) >= 0\n)\nor\n(\n  node_timex_offset_seconds < -0.05\nand\n  deriv(node_timex_offset_seconds[5m]) <= 0\n)\n"
+        for: 10m
+        labels:
+          severity: warning
+      - alert: NodeClockNotSynchronising
+        annotations:
+          message: '{% raw %}Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.{% endraw %}'
+          summary: 'Clock not synchronising.'
+        expr: "min_over_time(node_timex_sync_status[5m]) == 0\n"
+        for: 10m
+        labels:
+          severity: warning

--- a/templates/alert.rules.j2
+++ b/templates/alert.rules.j2
@@ -1,6 +1,4 @@
 {{ ansible_managed | comment }}
 
 groups:
-- name: ansible managed alert rules
-  rules:
-  {{ prometheus_alert_rules | to_nice_yaml(indent=2,sort_keys=False) | indent(2,False) }}
+{{ prometheus_alert_rules | to_nice_yaml(indent=2,sort_keys=False) | indent(2,False) }}


### PR DESCRIPTION
At the moment the assumption is a single rule group which is hard coded into the alert rules template. If you just move that back into `defaults/main.yml` and adjust the template accordingly, we can set our own rule groups, e.g.

```yaml
prometheus_alert_rules:
  - name: Connectivity
    rules:
      - alert: NetworkReceiveErrs
        annotations:
          description: '{% raw %}{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last two minutes.{% endraw %}'
          summary: 'Network interface is reporting many receive errors.'
        expr: "increase(node_network_receive_errs_total[2m]) > 10\n"
        for: 1h
        labels:
          severity: warning
      - alert: NetworkTransmitErrs
        annotations:
          description: '{% raw %}{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} transmit errors in the last two minutes.{% endraw %}'
          summary: 'Network interface is reporting many transmit errors.'
        expr: "increase(node_network_transmit_errs_total[2m]) > 10\n"
        for: 1h
        labels:
          severity: warning
  
  - name: Services
    rules:
      - alert: ServiceOomKillDetected
        expr: "increase(node_vmstat_oom_kill[1m]) > 0\n"
        for: 0m
        labels:
          severity: warning
        annotations:
          summary: '{% raw %}Host OOM kill detected (instance {{ $labels.instance }}){% endraw %}'
          description: '{% raw %}OOM kill detected\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}.{% endraw %}'
      - alert: ServiceNodeExporterDown
        expr: "node_systemd_unit_state{name=\"node_exporter.service\",state=\"active\",type=\"simple\"} == 0\n"
        for: 10m
        labels:
          severity: warning
        annotations:
          summary: '{% raw %}Prometheus Node Exporter service is stopped on host (instance {{ $labels.instance }}){% endraw %}'
          description: '{% raw %}Prometheus Node Exporter check reports the service is inactive:\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}.{% endraw %}'
      - alert: ServiceProcessExporterDown
        expr: "node_systemd_unit_state{name=\"process_exporter.service\",state=\"active\",type=\"simple\"} == 0\n"
        for: 10m
        labels:
          severity: warning
        annotations:
          summary: '{% raw %}Prometheus Process Exporter service is stopped on host (instance {{ $labels.instance }}){% endraw %}'
          description: '{% raw %}Prometheus Process Exporter check reports the service is inactive:\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}.{% endraw %}'
      - alert: ServiceSSHDown
        expr: "probe_success{job=~\".*ssh.*\"} == 0\n"
        for: 0m
        labels:
          severity: critical
        annotations:
          summary: '{% raw %}Host is not responding on port 22 (instance {{ $labels.instance }}){% endraw %}'
          description: '{% raw %}Monitoring port 22 and the probe success is\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}.{% endraw %}'
```

I moved the default behaviour into the config, so it's a non-breaking change for anything using the defaults currently but it expands functionality to allow others to set custom groups.