### PR TITLE
use -s for the kill signal

### DIFF
--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -11,7 +11,7 @@ Type=simple
 Environment="GOMAXPROCS={{ ansible_processor_vcpus|default(ansible_processor_count) }}"
 User=prometheus
 Group=prometheus
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/bin/kill -s SIGHUP $MAINPID
 ExecStart={{ _prometheus_binary_install_dir }}/prometheus \
   --storage.tsdb.path={{ prometheus_db_dir }} \
 {% if prometheus_version is version('2.7.0', '>=') %}


### PR DESCRIPTION
Hello,

When using kill with shorthand signal like `kill -HUP` Debian bullseye gives error  _kill: invalid argument H_

here is the prometheus _systemd_ config: 

```
ExecReload=/bin/kill -HUP $MAINPID
```

**OS Version:**
```
# lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 11 (bullseye)
Release:	11
Codename:	bullseye
```
**systemd logs**

```
Mar 27 15:03:23 prometheus systemd[1]: Reloading Prometheus.
Mar 27 15:03:23 prometheus prometheus[34185]: kill: invalid argument H
Mar 27 15:03:23 prometheus prometheus[34185]: Usage:
Mar 27 15:03:23 prometheus prometheus[34185]:  kill [options] <pid> [...]
Mar 27 15:03:23 prometheus prometheus[34185]: Options:
Mar 27 15:03:23 prometheus prometheus[34185]:  <pid> [...]            send signal to every <pid> listed
Mar 27 15:03:23 prometheus prometheus[34185]:  -<signal>, -s, --signal <signal>
Mar 27 15:03:23 prometheus prometheus[34185]:                         specify the <signal> to be sent
Mar 27 15:03:23 prometheus prometheus[34185]:  -q, --queue <value>    integer value to be sent with the signal
Mar 27 15:03:23 prometheus prometheus[34185]:  -l, --list=[<signal>]  list all signal names, or convert one to a name
Mar 27 15:03:23 prometheus prometheus[34185]:  -L, --table            list all signal names in a nice table
Mar 27 15:03:23 prometheus prometheus[34185]:  -h, --help     display this help and exit
Mar 27 15:03:23 prometheus prometheus[34185]:  -V, --version  output version information and exit
Mar 27 15:03:23 prometheus prometheus[34185]: For more details see kill(1).
Mar 27 15:03:23 prometheus systemd[1]: prometheus.service: Control process exited, code=exited, status=1/FAILURE
Mar 27 15:03:23 prometheus systemd[1]: Reload failed for Prometheus.
```

I think `kill -s SIGHUP` is more explicit usage.