### PR TITLE
Add configuration option for --web.route-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `prometheus_web_listen_address` | "0.0.0.0:9090" | Address on which prometheus will be listening |
 | `prometheus_web_config` | {} | A Prometheus [web config yaml](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md) for configuring TLS and auth. |
 | `prometheus_web_external_url` | "" | External address on which prometheus is available. Useful when behind reverse proxy. Ex. `http://example.org/prometheus` |
+| `prometheus_web_route_prefix` | (undefined) | Prefix for the internal routes of web endpoints |
 | `prometheus_storage_retention` | "30d" | Data retention period |
 | `prometheus_storage_retention_size` | "0" | Data retention period by size |
 | `prometheus_config_flags_extra` | {} | Additional configuration flags passed to prometheus binary at startup |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ prometheus_read_only_dirs: []
 
 prometheus_web_listen_address: "0.0.0.0:9090"
 prometheus_web_external_url: ''
+# uncomment below to set a route prefix (--web.route-prefix)
+# prometheus_web_route_prefix: '/'
 # See https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md
 prometheus_web_config:
   tls_server_config: {}

--- a/templates/prometheus.service.j2
+++ b/templates/prometheus.service.j2
@@ -27,6 +27,9 @@ ExecStart={{ _prometheus_binary_install_dir }}/prometheus \
   --web.console.templates={{ prometheus_config_dir }}/consoles \
   --web.listen-address={{ prometheus_web_listen_address }} \
   --web.external-url={{ prometheus_web_external_url }} \
+{% if  prometheus_web_route_prefix is defined %}
+  --web.route-prefix={{ prometheus_web_route_prefix }} \
+{% endif  %}
 {% for flag, flag_value in prometheus_config_flags_extra.items() %}
 {% if not flag_value %}
   --{{ flag }} \


### PR DESCRIPTION
Make the `--web-route-prefix` parameter configurable. This is useful when the URL configured by `--web.external-url=` contains a path (ref. https://github.com/prometheus/prometheus/issues/4925)