### PR TITLE
Allow grabbing prometheus binaries and checksums from a custom url/mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `prometheus_version` | 2.27.0 | Prometheus package version. Also accepts `latest` as parameter. Only prometheus 2.x is supported |
 | `prometheus_skip_install` | false | Prometheus installation tasks gets skipped when set to true. |
 | `prometheus_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `prometheus` AND `promtool` binaries are stored on host on which ansible is ran. This overrides `prometheus_version` parameter |
+| `prometheus_binary_url` | [defaults/main.yml#L5](defaults/main.yml#L5) | URL of the prometheus binaries .tar.gz file |
+| `prometheus_checksums_url` | [defaults/main.yml#L6](defaults/main.yml#L6) | URL of the prometheus checksums file |
 | `prometheus_config_dir` | /etc/prometheus | Path to directory with prometheus configuration |
 | `prometheus_db_dir` | /var/lib/prometheus | Path to directory with prometheus database |
 | `prometheus_read_only_dirs`| [] | Additional paths that Prometheus is allowed to read (useful for SSL certs outside of the config directory) |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 prometheus_version: 2.27.0
 prometheus_binary_local_dir: ''
 prometheus_skip_install: false
+prometheus_binary_url: https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,8 @@
 prometheus_version: 2.27.0
 prometheus_binary_local_dir: ''
 prometheus_skip_install: false
-prometheus_binary_url: https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz
+prometheus_binary_url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+prometheus_checksums_url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/sha256sums.txt"
 
 prometheus_config_dir: /etc/prometheus
 prometheus_db_dir: /var/lib/prometheus

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
     - name: download prometheus binary to local folder
       become: false
       get_url:
-        url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
+        url: "{{ prometheus_binary_url }}"
         dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ __prometheus_checksum }}"
       register: _download_archive

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -99,7 +99,7 @@
 - block:
     - name: "Get checksum list"
       set_fact:
-        __prometheus_checksums: "{{ lookup('url', 'https://github.com/prometheus/prometheus/releases/download/v' + prometheus_version + '/sha256sums.txt', wantlist=True) | list }}"
+        __prometheus_checksums: "{{ lookup('url', prometheus_checksums_url, wantlist=True) | list }}"
       run_once: true
 
     - name: "Get checksum for {{ go_arch }} architecture"


### PR DESCRIPTION
Allows grabbing prometheus binaries and checksums from a custom url/mirror, useful in closed environments where it's not possible to reach github.

I know the same could be achieved with custom tasks in a playbook and then using the `prometheus_binary_local_dir` variable, but it's pretty simple to just override the urls since they are defined anyways.

fixes #384 