### PR TITLE
Download prometheus remotely 

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -36,7 +36,6 @@
 
 - block:
     - name: download prometheus binary to local folder
-      become: false
       get_url:
         url: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
@@ -46,22 +45,20 @@
       retries: 5
       delay: 2
       # run_once: true # <-- this cannot be set due to multi-arch support
-      delegate_to: localhost
       check_mode: false
 
     - name: unpack prometheus binaries
-      become: false
       unarchive:
         src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp"
         creates: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/prometheus"
-      delegate_to: localhost
       check_mode: false
 
     - name: propagate official prometheus and promtool binaries
       copy:
         src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}"
         dest: "{{ _prometheus_binary_install_dir }}/{{ item }}"
+        remote_src: yes
         mode: 0755
         owner: root
         group: root
@@ -76,6 +73,7 @@
         src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}/"
         dest: "{{ prometheus_config_dir }}/{{ item }}/"
         mode: 0644
+        remote_src: yes
         owner: root
         group: root
       with_items:
@@ -91,6 +89,7 @@
   copy:
     src: "{{ prometheus_binary_local_dir }}/{{ item }}"
     dest: "{{ _prometheus_binary_install_dir }}/{{ item }}"
+    remote_src: yes
     mode: 0755
     owner: root
     group: root


### PR DESCRIPTION
Why not downloading it on the server directly? I had this error on my mac and thought it makes maybe sense to move the download directly to the server maybe?

```
fatal: [hetzner -> localhost]: FAILED! => {"changed": false, "msg": "Failed to find handler for \"/Users/robin.lehrmann/.ansible/tmp/ansible-tmp-1658956957.405443-31742-268351212854059/source\". Make sure the required command to extract the file is installed.\nCommand \"/usr/bin/tar\" detected as tar type bsd. GNU tar required.\nCommand \"/usr/bin/unzip\" could not handle archive:   End-of-central-directory signature not found.  Either this file is not\n  a zipfile, or it constitutes one disk of a multi-part archive.  In the\n  latter case the central directory and zipfile comment will be found on\n  the last disk(s) of this archive.\nnote:  /Users/robin.lehrmann/.ansible/tmp/ansible-tmp-1658956957.405443-31742-268351212854059/source may be a plain executable, not an archive\nunzip:  cannot find zipfile directory in one of /Users/robin.lehrmann/.ansible/tmp/ansible-tmp-1658956957.405443-31742-268351212854059/source or\n        /Users/robin.lehrmann/.ansible/tmp/ansible-tmp-1658956957.405443-31742-268351212854059/source.zip, and cannot find /Users/robin.lehrmann/.ansible/tmp/ansible-tmp-1658956957.405443-31742-268351212854059/source.ZIP, period.\n"}
```